### PR TITLE
chore(db): PostgreSQL for API and tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,8 @@
 # WEB env lives in apps/web/.env
 
 # --- API ---
-DATABASE_URL=sqlite:///./recruit.db
+# PostgreSQL (host port 5433 maps to 5432 in Docker; see docker/docker-compose.yml)
+DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5433/recruit_db
 SECRET_KEY=your-super-secret-key-change-in-production
 ALGORITHM=HS256
 ACCESS_TOKEN_EXPIRE_MINUTES=30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,20 @@ on:
 jobs:
   backend:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: recruit_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
     steps:
       - uses: actions/checkout@v4
 
@@ -33,7 +47,7 @@ jobs:
           cd apps/api
           python -c "from app.main import app; print('OK')"
         env:
-          DATABASE_URL: sqlite:///./recruit.db
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/recruit_test
           SECRET_KEY: ci-secret-key
 
       - name: Run tests
@@ -41,7 +55,7 @@ jobs:
           cd apps/api
           pytest tests/ -v --tb=short
         env:
-          DATABASE_URL: sqlite://
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/recruit_test
           SECRET_KEY: ci-secret-key
 
   frontend:

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ __pycache__/
 .env.local
 *.env
 
-# SQLite (local dev)
+# Local DB files (e.g. legacy SQLite)
 *.db
 
 # Build / dist

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,4 +1,4 @@
-﻿# Architecture
+# Architecture
 
 ## Apps
 
@@ -21,8 +21,7 @@
 
 ## Runtime
 
-- API default local DB: SQLite (`sqlite:///./recruit.db`)
-- Optional DB: PostgreSQL via docker compose
+- API database: PostgreSQL (see `docker/docker-compose.yml`; host port `5433` → container `5432`)
 - Frontend talks to API via Vite proxy (`/api`) in dev
 
 ## CI/CD

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,5 +1,6 @@
-# Database: sqlite for dev, postgres for prod
-DATABASE_URL=sqlite:///./recruit.db
+# PostgreSQL — start DB: docker compose -f docker/docker-compose.yml up -d postgres
+# Pytest uses database `recruit_test` on the same host/port (see docker/postgres-init/).
+DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5433/recruit_db
 SECRET_KEY=your-super-secret-key-change-in-production
 ALGORITHM=HS256
 ACCESS_TOKEN_EXPIRE_MINUTES=30

--- a/apps/api/app/config.py
+++ b/apps/api/app/config.py
@@ -7,8 +7,8 @@ _env_path = Path(__file__).parent.parent / ".env"
 
 
 class Settings(BaseSettings):
-    # Use SQLite for quick local run when Docker/Postgres unavailable
-    DATABASE_URL: str = "sqlite:///./recruit.db"
+    # Local dev: run `docker compose -f docker/docker-compose.yml up -d postgres` (port 5433)
+    DATABASE_URL: str = "postgresql://postgres:postgres@127.0.0.1:5433/recruit_db"
     SECRET_KEY: str = "your-super-secret-key-change-in-production"
     ALGORITHM: str = "HS256"
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 30

--- a/apps/api/app/database.py
+++ b/apps/api/app/database.py
@@ -4,10 +4,7 @@ from sqlalchemy.orm import sessionmaker
 
 from app.config import settings
 
-_connect_args = {}
-if settings.DATABASE_URL.startswith("sqlite"):
-    _connect_args["check_same_thread"] = False
-engine = create_engine(settings.DATABASE_URL, connect_args=_connect_args)
+engine = create_engine(settings.DATABASE_URL)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 Base = declarative_base()
 

--- a/apps/api/init_db.py
+++ b/apps/api/init_db.py
@@ -2,27 +2,44 @@
 from sqlalchemy import text
 
 from app.database import Base, engine
-from app.models import AuditLog, OTP, PasswordResetToken, User, UserSession  # noqa: F401
+from app.models import OTP, AuditLog, PasswordResetToken, User, UserSession  # noqa: F401
+
+
+def _migrate_users_columns_postgresql(conn) -> None:
+    """Add legacy columns on older deployments if missing."""
+    rows = conn.execute(
+        text(
+            """
+            SELECT column_name FROM information_schema.columns
+            WHERE table_schema = 'public' AND table_name = 'users'
+            """
+        )
+    ).fetchall()
+    existing = {r[0] for r in rows}
+    alters: list[str] = []
+    if "is_email_verified" not in existing:
+        alters.append(
+            "ALTER TABLE users ADD COLUMN is_email_verified BOOLEAN DEFAULT FALSE NOT NULL"
+        )
+    if "failed_login_attempts" not in existing:
+        alters.append(
+            "ALTER TABLE users ADD COLUMN failed_login_attempts INTEGER DEFAULT 0 NOT NULL"
+        )
+    if "failed_login_window_started_at" not in existing:
+        alters.append(
+            "ALTER TABLE users ADD COLUMN failed_login_window_started_at TIMESTAMP WITH TIME ZONE"
+        )
+    if "locked_until" not in existing:
+        alters.append("ALTER TABLE users ADD COLUMN locked_until TIMESTAMP WITH TIME ZONE")
+    if "last_login_at" not in existing:
+        alters.append("ALTER TABLE users ADD COLUMN last_login_at TIMESTAMP WITH TIME ZONE")
+    for sql in alters:
+        conn.execute(text(sql))
+
 
 if __name__ == "__main__":
     Base.metadata.create_all(bind=engine)
-    # Migration: add is_email_verified if missing
-    with engine.connect() as conn:
-        if engine.url.get_backend_name() == "sqlite":
-            cols = [r[1] for r in conn.execute(text("PRAGMA table_info(users)")).fetchall()]
-            if "is_email_verified" not in cols:
-                conn.execute(text("ALTER TABLE users ADD COLUMN is_email_verified BOOLEAN DEFAULT 0"))
-            if "failed_login_attempts" not in cols:
-                conn.execute(
-                    text("ALTER TABLE users ADD COLUMN failed_login_attempts INTEGER DEFAULT 0")
-                )
-            if "failed_login_window_started_at" not in cols:
-                conn.execute(
-                    text("ALTER TABLE users ADD COLUMN failed_login_window_started_at DATETIME")
-                )
-            if "locked_until" not in cols:
-                conn.execute(text("ALTER TABLE users ADD COLUMN locked_until DATETIME"))
-            if "last_login_at" not in cols:
-                conn.execute(text("ALTER TABLE users ADD COLUMN last_login_at DATETIME"))
-            conn.commit()
+    if engine.url.get_backend_name() == "postgresql":
+        with engine.begin() as conn:
+            _migrate_users_columns_postgresql(conn)
     print("Database ready.")

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -1,40 +1,22 @@
-"""Shared test fixtures: isolated in-memory DB, TestClient, OTP capture."""
+"""Shared test fixtures: PostgreSQL test DB, TestClient, OTP capture."""
 
 import os
 
-# Force SQLite in-memory BEFORE any app module is imported so that
-# database.py / main.py never try to connect to PostgreSQL.
-os.environ["DATABASE_URL"] = "sqlite://"
+# Must be set before app imports so database.py binds to the test database.
+os.environ.setdefault(
+    "DATABASE_URL",
+    "postgresql://postgres:postgres@127.0.0.1:5433/recruit_test",
+)
+os.environ.setdefault("SECRET_KEY", "test-secret-key-for-pytest")
 
 from collections import defaultdict
 from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient
-from sqlalchemy import create_engine, event
-from sqlalchemy.orm import sessionmaker
-from sqlalchemy.pool import StaticPool
 
-from app.database import Base, get_db
+from app.database import Base, SessionLocal, engine, get_db
 from app.main import app
-
-# ---------------------------------------------------------------------------
-# In-memory SQLite engine – StaticPool keeps one shared connection so that
-# table creation and request handling see the same database.
-# ---------------------------------------------------------------------------
-engine = create_engine(
-    "sqlite://",
-    connect_args={"check_same_thread": False},
-    poolclass=StaticPool,
-)
-TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-
-
-@event.listens_for(engine, "connect")
-def _set_sqlite_pragma(dbapi_conn, _):
-    cursor = dbapi_conn.cursor()
-    cursor.execute("PRAGMA foreign_keys=ON")
-    cursor.close()
 
 
 # ---------------------------------------------------------------------------
@@ -42,7 +24,8 @@ def _set_sqlite_pragma(dbapi_conn, _):
 # ---------------------------------------------------------------------------
 @pytest.fixture(autouse=True)
 def _setup_db():
-    """Create all tables before each test; drop after."""
+    """Recreate schema before each test; tear down after."""
+    Base.metadata.drop_all(bind=engine)
     Base.metadata.create_all(bind=engine)
     yield
     Base.metadata.drop_all(bind=engine)
@@ -50,7 +33,7 @@ def _setup_db():
 
 @pytest.fixture()
 def db():
-    session = TestingSessionLocal()
+    session = SessionLocal()
     try:
         yield session
     finally:
@@ -58,7 +41,7 @@ def db():
 
 
 def _override_get_db():
-    session = TestingSessionLocal()
+    session = SessionLocal()
     try:
         yield session
     finally:
@@ -67,7 +50,7 @@ def _override_get_db():
 
 @pytest.fixture(autouse=True)
 def _override_deps():
-    """Swap the production DB dependency with the test DB for every request."""
+    """Swap the production DB dependency with the test session for every request."""
     app.dependency_overrides[get_db] = _override_get_db
     yield
     app.dependency_overrides.clear()
@@ -144,7 +127,7 @@ def make_verified_user(client, captured_otps):
         if role != "candidate":
             from app.models.user import User
 
-            session = TestingSessionLocal()
+            session = SessionLocal()
             user = session.query(User).filter(User.email == email.lower()).first()
             if user:
                 user.role = role

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - "5433:5432"  # 5433 to avoid conflict with other PostgreSQL on 5432
     volumes:
       - pgdata:/var/lib/postgresql/data
+      - ./postgres-init:/docker-entrypoint-initdb.d:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 3s

--- a/docker/postgres-init/01-create-test-db.sql
+++ b/docker/postgres-init/01-create-test-db.sql
@@ -1,0 +1,3 @@
+-- Pytest uses database `recruit_test` (see apps/api/tests/conftest.py).
+-- Runs only on first PostgreSQL data directory init.
+CREATE DATABASE recruit_test;

--- a/scripts/run-backend.ps1
+++ b/scripts/run-backend.ps1
@@ -1,8 +1,6 @@
-# Run backend - SQLite by default (no Docker needed)
-# For PostgreSQL: set DATABASE_URL in apps/api/.env before running
-if (-not $env:DATABASE_URL -or $env:DATABASE_URL -like "*postgresql*") {
-    # Use SQLite if no DB set or postgres fails
-    $env:DATABASE_URL = "sqlite:///./recruit.db"
+# Run backend — expects PostgreSQL (see docker/docker-compose.yml, port 5433 on host)
+if (-not $env:DATABASE_URL) {
+    $env:DATABASE_URL = "postgresql://postgres:postgres@127.0.0.1:5433/recruit_db"
 }
 if (-not $env:SECRET_KEY) { $env:SECRET_KEY = "dev-secret-key" }
 


### PR DESCRIPTION
## Summary
Removes SQLite defaults and uses PostgreSQL everywhere for the API and pytest.

## Changes
- Default \DATABASE_URL\ points at local Docker Postgres (host port **5433**).
- \database.py\: no SQLite \connect_args\.
- \init_db.py\: legacy column migration via \information_schema\ (PostgreSQL).
- **CI**: Postgres 16 service; pytest uses \
ecruit_test\ on \localhost:5432\.
- **Docker**: \docker/postgres-init/\ creates \
ecruit_test\ on first DB init.
- \
un-backend.ps1\, \.env.example\, \ARCHITECTURE.md\ updated; \.gitignore\ includes \*.db\.

## How to verify
1. \docker compose -f docker/docker-compose.yml up -d postgres\
2. \./scripts/run-backend.ps1\ and \./scripts/run-frontend.ps1\
3. From \pps/api\: \pytest tests/ -v\ (with Postgres running)

By Abdellah T.