### PR TITLE
Recruitment dashboards (candidate/recruiter), theme, and /dashboard routing

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -4,7 +4,13 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>frontend</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400&display=swap"
+      rel="stylesheet"
+    />
+    <title>AI-Powered Recruitment</title>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
-import { ThemeProvider, createTheme, CssBaseline } from '@mui/material';
+import { Box, CircularProgress, ThemeProvider, CssBaseline } from '@mui/material';
 import { AuthProvider } from './contexts/AuthContext';
 import { useAuth } from './contexts/useAuth';
 import ForgotPassword from './pages/ForgotPassword';
@@ -13,21 +13,25 @@ import AdminLayout from './pages/admin/AdminLayout';
 import AdminDashboard from './pages/admin/AdminDashboard';
 import AdminUsers from './pages/admin/AdminUsers';
 import AdminAuditLogs from './pages/admin/AdminAuditLogs';
-
-const theme = createTheme({
-  palette: {
-    primary: { main: '#1976d2' },
-  },
-});
+import RecruitLayout from './layouts/RecruitLayout';
+import CandidateDashboard from './pages/candidate/CandidateDashboard';
+import CandidateJobsPage from './pages/candidate/CandidateJobsPage';
+import CandidateApplicationsPage from './pages/candidate/CandidateApplicationsPage';
+import RecruiterDashboard from './pages/recruiter/RecruiterDashboard';
+import RecruiterJobsPage from './pages/recruiter/RecruiterJobsPage';
+import RecruiterCandidatesPage from './pages/recruiter/RecruiterCandidatesPage';
+import ProfilePage from './pages/shared/ProfilePage';
+import { appTheme } from './theme';
 
 function App() {
   return (
-    <ThemeProvider theme={theme}>
+    <ThemeProvider theme={appTheme}>
       <CssBaseline />
       <AuthProvider>
         <BrowserRouter>
           <Routes>
             <Route path="/" element={<Home />} />
+            <Route path="/dashboard" element={<DashboardRedirect />} />
             <Route
               path="/signin"
               element={
@@ -61,21 +65,33 @@ function App() {
               }
             />
             <Route
-              path="/dashboard"
+              path="/candidate"
               element={
-                <RequireAuth>
-                  <Home />
-                </RequireAuth>
+                <RequireRole role="candidate">
+                  <RecruitLayout variant="candidate" />
+                </RequireRole>
               }
-            />
+            >
+              <Route index element={<Navigate to="dashboard" replace />} />
+              <Route path="dashboard" element={<CandidateDashboard />} />
+              <Route path="jobs" element={<CandidateJobsPage />} />
+              <Route path="applications" element={<CandidateApplicationsPage />} />
+              <Route path="profile" element={<ProfilePage />} />
+            </Route>
             <Route
               path="/recruiter"
               element={
                 <RequireRole role="recruiter">
-                  <Home />
+                  <RecruitLayout variant="recruiter" />
                 </RequireRole>
               }
-            />
+            >
+              <Route index element={<Navigate to="dashboard" replace />} />
+              <Route path="dashboard" element={<RecruiterDashboard />} />
+              <Route path="jobs" element={<RecruiterJobsPage />} />
+              <Route path="candidates" element={<RecruiterCandidatesPage />} />
+              <Route path="profile" element={<ProfilePage />} />
+            </Route>
             <Route
               path="/admin"
               element={
@@ -97,25 +113,45 @@ function App() {
   );
 }
 
-function RequireAuth({ children }: { children: ReactNode }) {
-  const { isAuthenticated, isLoading } = useAuth();
-  if (isLoading) return <Home />;
+/** Sends signed-in users to the right hub: admin → /admin, recruiter → /recruiter/dashboard, everyone else → /candidate/dashboard. */
+function DashboardRedirect() {
+  const { user, isAuthenticated, isLoading } = useAuth();
+  if (isLoading) {
+    return (
+      <Box
+        sx={{
+          minHeight: '100vh',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          bgcolor: 'background.default',
+        }}
+      >
+        <CircularProgress />
+      </Box>
+    );
+  }
   if (!isAuthenticated) return <Navigate to="/signin" replace />;
-  return children;
+  const r = (user?.role || '').toLowerCase();
+  if (r === 'admin') return <Navigate to="/admin" replace />;
+  if (r === 'recruiter') return <Navigate to="/recruiter/dashboard" replace />;
+  return <Navigate to="/candidate/dashboard" replace />;
 }
 
 function GuestOnly({ children }: { children: ReactNode }) {
   const { isAuthenticated, isLoading } = useAuth();
-  if (isLoading) return <Home />;
-  if (isAuthenticated) return <Navigate to="/" replace />;
+  if (isLoading) return null;
+  if (isAuthenticated) return <Navigate to="/dashboard" replace />;
   return children;
 }
 
 function RequireRole({ role, children }: { role: string; children: ReactNode }) {
   const { user, isAuthenticated, isLoading } = useAuth();
-  if (isLoading) return <Home />;
+  if (isLoading) return null;
   if (!isAuthenticated) return <Navigate to="/signin" replace />;
-  if ((user?.role || '').toLowerCase() !== role.toLowerCase() && user?.role !== 'admin') {
+  const r = (user?.role || '').toLowerCase();
+  const need = role.toLowerCase();
+  if (r !== need && r !== 'admin') {
     return <Navigate to="/unauthorized" replace />;
   }
   return children;

--- a/apps/web/src/components/LanguageSwitcher.tsx
+++ b/apps/web/src/components/LanguageSwitcher.tsx
@@ -1,11 +1,13 @@
+import type { SxProps, Theme } from '@mui/material/styles';
 import { useTranslation } from 'react-i18next';
 import { ToggleButton, ToggleButtonGroup } from '@mui/material';
 
-export default function LanguageSwitcher() {
+export default function LanguageSwitcher({ sx }: { sx?: SxProps<Theme> }) {
   const { i18n } = useTranslation();
 
   return (
     <ToggleButtonGroup
+      sx={sx}
       value={i18n.language?.startsWith('am') ? 'am' : 'en'}
       exclusive
       onChange={(_, lang) => lang && i18n.changeLanguage(lang)}

--- a/apps/web/src/data/mockRecruit.ts
+++ b/apps/web/src/data/mockRecruit.ts
@@ -1,0 +1,112 @@
+/** Placeholder data until job/application APIs exist. */
+
+export type MockJob = {
+  id: string;
+  title: string;
+  company: string;
+  location: string;
+  type: 'full_time' | 'contract' | 'part_time';
+  postedAt: string;
+  matchPct: number;
+};
+
+export type MockApplication = {
+  id: string;
+  jobTitle: string;
+  company: string;
+  stage: 'applied' | 'screening' | 'interview' | 'offer' | 'rejected';
+  updatedAt: string;
+};
+
+export type MockRecruiterJob = {
+  id: string;
+  title: string;
+  applicants: number;
+  status: 'open' | 'paused' | 'closed';
+  postedAt: string;
+};
+
+export type MockPipelineRow = {
+  id: string;
+  candidateName: string;
+  jobTitle: string;
+  stage: 'new' | 'screening' | 'interview' | 'offer';
+  updatedAt: string;
+};
+
+export const MOCK_JOBS: MockJob[] = [
+  {
+    id: 'j1',
+    title: 'Senior Frontend Engineer',
+    company: 'Northwind Labs',
+    location: 'Remote · EU',
+    type: 'full_time',
+    postedAt: '2026-03-26',
+    matchPct: 94,
+  },
+  {
+    id: 'j2',
+    title: 'Product Designer',
+    company: 'Blue River',
+    location: 'Addis Ababa · Hybrid',
+    type: 'full_time',
+    postedAt: '2026-03-24',
+    matchPct: 88,
+  },
+  {
+    id: 'j3',
+    title: 'ML Engineer (NLP)',
+    company: 'Atlas AI',
+    location: 'Remote',
+    type: 'contract',
+    postedAt: '2026-03-22',
+    matchPct: 81,
+  },
+];
+
+export const MOCK_APPLICATIONS: MockApplication[] = [
+  {
+    id: 'a1',
+    jobTitle: 'Frontend Engineer',
+    company: 'Kinetix',
+    stage: 'interview',
+    updatedAt: '2026-03-27',
+  },
+  {
+    id: 'a2',
+    jobTitle: 'UX Researcher',
+    company: 'Helio',
+    stage: 'screening',
+    updatedAt: '2026-03-25',
+  },
+];
+
+export const MOCK_RECRUITER_JOBS: MockRecruiterJob[] = [
+  { id: 'rj1', title: 'Backend Developer', applicants: 12, status: 'open', postedAt: '2026-03-20' },
+  { id: 'rj2', title: 'DevOps Engineer', applicants: 5, status: 'open', postedAt: '2026-03-18' },
+  { id: 'rj3', title: 'HR Coordinator', applicants: 0, status: 'paused', postedAt: '2026-03-10' },
+];
+
+export const MOCK_PIPELINE: MockPipelineRow[] = [
+  {
+    id: 'p1',
+    candidateName: 'Sara Hailu',
+    jobTitle: 'Backend Developer',
+    stage: 'interview',
+    updatedAt: '2026-03-28',
+  },
+  {
+    id: 'p2',
+    candidateName: 'Daniel Tesfaye',
+    jobTitle: 'Backend Developer',
+    stage: 'screening',
+    updatedAt: '2026-03-27',
+  },
+  {
+    id: 'p3',
+    candidateName: 'Meron Alem',
+    jobTitle: 'DevOps Engineer',
+    stage: 'new',
+    updatedAt: '2026-03-26',
+  },
+];

--- a/apps/web/src/i18n/am.json
+++ b/apps/web/src/i18n/am.json
@@ -79,13 +79,114 @@
     "title": "ያልተፈቀደ",
     "message": "ይህን ገጽ ለመድረስ ፈቃድ የለዎትም።"
   },
+  "recruit": {
+    "workspace": "የስራ ቦታ",
+    "candidateHub": "የእምሰራተኛ ማዕከል",
+    "recruiterHub": "የቅጥር ሰው ማዕከል",
+    "mockNotice": "የአቋራ እይታ ለማሳየት። በቅርቡ API ይገናኛል።",
+    "match": "ይዛመዳል",
+    "nav": {
+      "dashboard": "ዳሽቦርድ",
+      "jobs": "ስራዎች",
+      "applications": "የእኔ ማመልከቻዎች",
+      "jobPostings": "የስራ ማስታወሻዎች",
+      "candidates": "እምሰራተኞች",
+      "profile": "መገለጫ"
+    },
+    "stats": {
+      "activeApplications": "ንቁ ማመልከቻዎች",
+      "jobsMatched": "የተዛመዱ ስራዎች",
+      "profileStrength": "የመገለጫ ጥንካሬ",
+      "openRoles": "ክፍት ሚናዎች",
+      "totalApplicants": "በመስመር ላይ አመልካቾች",
+      "newThisWeek": "በዚህ ሳምንት አዲስ"
+    },
+    "jobType": {
+      "full_time": "ሙሉ ጊዜ",
+      "contract": "ኮንትራት",
+      "part_time": "ከፊል ጊዜ"
+    },
+    "jobStatus": {
+      "open": "ክፍት",
+      "paused": "ተቆሟል",
+      "closed": "ተዘጋ"
+    },
+    "stage": {
+      "applied": "ተመዝገበ",
+      "screening": "መርምር",
+      "interview": "ቃለ መጠይቅ",
+      "offer": "ቅድመ ውል",
+      "rejected": "ተቀባይነት አላገኘም"
+    },
+    "pipelineStage": {
+      "new": "አዲስ",
+      "screening": "መርምር",
+      "interview": "ቃለ መጠይቅ",
+      "offer": "ቅድመ ውል"
+    },
+    "candidate": {
+      "dashboardTitle": "የቅጥር አጠቃላይ እይታ",
+      "dashboardSubtitle": "ማመልከቻዎችን ይከታተሉ እና የሚስማሙ ስራዎችን ያግኙ።",
+      "topMatch": "ለእርስዎ ከፍተኛ ተዛማጅ",
+      "browseJobs": "ስራዎችን ይመልከቱ",
+      "pipelinePreview": "የማመልከቻ መስመር",
+      "viewApplications": "ሁሉንም ማመልከቻዎች ይመልከቱ"
+    },
+    "jobs": {
+      "browseTitle": "ስራዎችን ያግኙ",
+      "browseSubtitle": "በመገለጽዎ ላይ የተመሰረተ (ለአሁን ቅድመ እይታ)።",
+      "apply": "ያመልክቱ",
+      "save": "አስቀምጥ"
+    },
+    "applications": {
+      "title": "የእኔ ማመልከቻዎች",
+      "subtitle": "በሁሉም ስራዎች ላይ የሁኔታ ማዘመኖች።",
+      "colRole": "ሚና",
+      "colCompany": "ኩባንያ",
+      "colStage": "ደረጃ",
+      "colUpdated": "ተዘምኗል"
+    },
+    "recruiter": {
+      "dashboardTitle": "የቅጥር መስመር",
+      "dashboardSubtitle": "ክፍት ሚናዎችን፣ አዲስ አመልካቾችን ይከታተሉ።",
+      "yourPostings": "የእርስዎ ማስታወሻዎች",
+      "manageJobs": "አስተዳድር",
+      "posted": "የተለጠፈ {{date}}",
+      "applicants": "አመልካቾች",
+      "pipelinePreview": "የመስመር ቅድመ እይታ",
+      "openPipeline": "መስመር ክፈት",
+      "jobsTitle": "የስራ ማስታወሻዎች",
+      "jobsSubtitle": "ሚናዎችን ያስታውቁ፣ አመልካቾችን ይከታተሉ።",
+      "newPosting": "አዲስ ማስታወሻ",
+      "edit": "አርም",
+      "viewApplicants": "አመልካቾችን ይመልከቱ"
+    },
+    "pipeline": {
+      "title": "የእምሰራተኛ መስመር",
+      "subtitle": "በደረጃዎች አመልካቾችን ይገምግሙ።",
+      "colCandidate": "እምሰራተኛ",
+      "colRole": "ሚና",
+      "colStage": "ደረጃ",
+      "colUpdated": "ተዘምኗል"
+    },
+    "profile": {
+      "title": "መገለጫ",
+      "subtitle": "ከመገለጽዎ የተገኙ መረጃዎች።",
+      "role": "ሚና",
+      "editHint": "የመገለጫ ማስተካከያ በኋላ በ API ሲገኝ ይገኛል።"
+    },
+    "adminPanel": "የአስተዳዳሪ ፓነል"
+  },
   "admin": {
     "title": "የአስተዳዳሪ ዳሽቦርድ",
     "goToDashboard": "የአስተዳዳሪ ዳሽቦርድ",
     "nav": {
       "dashboard": "ዳሽቦርድ",
       "users": "ተጠቃሚዎች",
-      "auditLogs": "የኦዲት ምዝግብ ማስታወሻዎች"
+      "auditLogs": "የኦዲት ምዝግብ ማስታወሻዎች",
+      "previewWorkspaces": "ቅድመ እይታ",
+      "candidateHub": "የእምሰራተኛ ማዕከል",
+      "recruiterHub": "የቅጥር ሰው ማዕከል"
     },
     "stats": {
       "totalUsers": "ጠቅላላ ተጠቃሚዎች",

--- a/apps/web/src/i18n/en.json
+++ b/apps/web/src/i18n/en.json
@@ -79,13 +79,114 @@
     "title": "Unauthorized",
     "message": "You do not have permission to access this page."
   },
+  "recruit": {
+    "workspace": "Workspace",
+    "candidateHub": "Candidate hub",
+    "recruiterHub": "Recruiter hub",
+    "mockNotice": "Sample data for layout preview. Wire up job and application APIs to replace this.",
+    "match": "match",
+    "nav": {
+      "dashboard": "Dashboard",
+      "jobs": "Jobs",
+      "applications": "My applications",
+      "jobPostings": "Job postings",
+      "candidates": "Candidates",
+      "profile": "Profile"
+    },
+    "stats": {
+      "activeApplications": "Active applications",
+      "jobsMatched": "Matched roles",
+      "profileStrength": "Profile strength",
+      "openRoles": "Open roles",
+      "totalApplicants": "Applicants in pipeline",
+      "newThisWeek": "New this week"
+    },
+    "jobType": {
+      "full_time": "Full-time",
+      "contract": "Contract",
+      "part_time": "Part-time"
+    },
+    "jobStatus": {
+      "open": "Open",
+      "paused": "Paused",
+      "closed": "Closed"
+    },
+    "stage": {
+      "applied": "Applied",
+      "screening": "Screening",
+      "interview": "Interview",
+      "offer": "Offer",
+      "rejected": "Rejected"
+    },
+    "pipelineStage": {
+      "new": "New",
+      "screening": "Screening",
+      "interview": "Interview",
+      "offer": "Offer"
+    },
+    "candidate": {
+      "dashboardTitle": "Your hiring overview",
+      "dashboardSubtitle": "Track applications and discover roles that fit your profile.",
+      "topMatch": "Top match for you",
+      "browseJobs": "Browse jobs",
+      "pipelinePreview": "Application pipeline",
+      "viewApplications": "View all applications"
+    },
+    "jobs": {
+      "browseTitle": "Discover roles",
+      "browseSubtitle": "AI-ranked matches based on your profile (placeholder).",
+      "apply": "Apply",
+      "save": "Save"
+    },
+    "applications": {
+      "title": "My applications",
+      "subtitle": "Status updates across every role you have applied to.",
+      "colRole": "Role",
+      "colCompany": "Company",
+      "colStage": "Stage",
+      "colUpdated": "Updated"
+    },
+    "recruiter": {
+      "dashboardTitle": "Recruiting pipeline",
+      "dashboardSubtitle": "Monitor open roles, new applicants, and next actions.",
+      "yourPostings": "Your postings",
+      "manageJobs": "Manage",
+      "posted": "Posted {{date}}",
+      "applicants": "applicants",
+      "pipelinePreview": "Latest pipeline",
+      "openPipeline": "Open pipeline",
+      "jobsTitle": "Job postings",
+      "jobsSubtitle": "Publish roles, track applicants, and collaborate with your team.",
+      "newPosting": "New posting",
+      "edit": "Edit",
+      "viewApplicants": "View applicants"
+    },
+    "pipeline": {
+      "title": "Candidate pipeline",
+      "subtitle": "Review candidates across stages.",
+      "colCandidate": "Candidate",
+      "colRole": "Role",
+      "colStage": "Stage",
+      "colUpdated": "Updated"
+    },
+    "profile": {
+      "title": "Profile",
+      "subtitle": "Account information from your profile.",
+      "role": "Role",
+      "editHint": "Profile editing will be available when your backend exposes update endpoints."
+    },
+    "adminPanel": "Admin panel"
+  },
   "admin": {
     "title": "Admin Dashboard",
     "goToDashboard": "Admin Dashboard",
     "nav": {
       "dashboard": "Dashboard",
       "users": "Users",
-      "auditLogs": "Audit Logs"
+      "auditLogs": "Audit Logs",
+      "previewWorkspaces": "Preview",
+      "candidateHub": "Candidate hub",
+      "recruiterHub": "Recruiter hub"
     },
     "stats": {
       "totalUsers": "Total Users",

--- a/apps/web/src/layouts/RecruitLayout.tsx
+++ b/apps/web/src/layouts/RecruitLayout.tsx
@@ -1,0 +1,224 @@
+import {
+  AppBar,
+  Box,
+  Chip,
+  Drawer,
+  IconButton,
+  List,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  Toolbar,
+  Typography,
+  useMediaQuery,
+  useTheme,
+} from '@mui/material';
+import MenuIcon from '@mui/icons-material/Menu';
+import DashboardIcon from '@mui/icons-material/Dashboard';
+import WorkIcon from '@mui/icons-material/Work';
+import AssignmentIcon from '@mui/icons-material/Assignment';
+import PersonIcon from '@mui/icons-material/Person';
+import GroupIcon from '@mui/icons-material/Group';
+import type { ReactNode } from 'react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Outlet, useLocation, useNavigate } from 'react-router-dom';
+import LanguageSwitcher from '../components/LanguageSwitcher';
+import { useAuth } from '../contexts/useAuth';
+
+const DRAWER_WIDTH = 268;
+
+export type RecruitVariant = 'candidate' | 'recruiter';
+
+type NavItem = { labelKey: string; path: string; icon: ReactNode };
+
+export default function RecruitLayout({ variant }: { variant: RecruitVariant }) {
+  const { t } = useTranslation();
+  const theme = useTheme();
+  const isSmUp = useMediaQuery(theme.breakpoints.up('sm'));
+  const [mobileOpen, setMobileOpen] = useState(false);
+  const { user, logout } = useAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const base = variant === 'candidate' ? '/candidate' : '/recruiter';
+
+  const candidateNav: NavItem[] = [
+    { labelKey: 'recruit.nav.dashboard', path: `${base}/dashboard`, icon: <DashboardIcon /> },
+    { labelKey: 'recruit.nav.jobs', path: `${base}/jobs`, icon: <WorkIcon /> },
+    { labelKey: 'recruit.nav.applications', path: `${base}/applications`, icon: <AssignmentIcon /> },
+    { labelKey: 'recruit.nav.profile', path: `${base}/profile`, icon: <PersonIcon /> },
+  ];
+
+  const recruiterNav: NavItem[] = [
+    { labelKey: 'recruit.nav.dashboard', path: `${base}/dashboard`, icon: <DashboardIcon /> },
+    { labelKey: 'recruit.nav.jobPostings', path: `${base}/jobs`, icon: <WorkIcon /> },
+    { labelKey: 'recruit.nav.candidates', path: `${base}/candidates`, icon: <GroupIcon /> },
+    { labelKey: 'recruit.nav.profile', path: `${base}/profile`, icon: <PersonIcon /> },
+  ];
+
+  const navItems = variant === 'candidate' ? candidateNav : recruiterNav;
+
+  const drawer = (
+    <Box sx={{ pt: 1, display: 'flex', flexDirection: 'column', minHeight: 'calc(100vh - 64px)' }}>
+      <Box sx={{ px: 2.5, pb: 2 }}>
+        <Typography variant="overline" color="text.secondary" sx={{ letterSpacing: '0.12em' }}>
+          {t('recruit.workspace')}
+        </Typography>
+        <Typography variant="h6" sx={{ fontWeight: 700, color: 'primary.main', lineHeight: 1.2 }}>
+          {variant === 'candidate' ? t('recruit.candidateHub') : t('recruit.recruiterHub')}
+        </Typography>
+      </Box>
+      <List sx={{ px: 1, flex: '1 1 auto' }}>
+        {navItems.map((item) => (
+          <ListItemButton
+            key={item.path}
+            selected={location.pathname === item.path}
+            onClick={() => {
+              navigate(item.path);
+              setMobileOpen(false);
+            }}
+            sx={{
+              borderRadius: 2,
+              mb: 0.5,
+              '&.Mui-selected': {
+                bgcolor: 'primary.main',
+                color: 'primary.contrastText',
+                '& .MuiListItemIcon-root': { color: 'inherit' },
+              },
+            }}
+          >
+            <ListItemIcon sx={{ minWidth: 40, color: 'inherit' }}>{item.icon}</ListItemIcon>
+            <ListItemText primary={t(item.labelKey)} />
+          </ListItemButton>
+        ))}
+      </List>
+      {user?.role === 'admin' && (
+        <Box sx={{ px: 2, pt: 2, pb: 2, mt: 'auto' }}>
+          <ListItemButton
+            onClick={() => {
+              navigate('/admin');
+              setMobileOpen(false);
+            }}
+            sx={{ borderRadius: 2, border: '1px dashed', borderColor: 'divider' }}
+          >
+            <ListItemText primary={t('recruit.adminPanel')} />
+          </ListItemButton>
+        </Box>
+      )}
+    </Box>
+  );
+
+  return (
+    <Box sx={{ display: 'flex', minHeight: '100vh', bgcolor: 'background.default' }}>
+      <AppBar
+        position="fixed"
+        sx={{
+          width: { sm: `calc(100% - ${DRAWER_WIDTH}px)` },
+          ml: { sm: `${DRAWER_WIDTH}px` },
+        }}
+      >
+        <Toolbar sx={{ justifyContent: 'space-between', gap: 2 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            {!isSmUp && (
+              <IconButton color="inherit" edge="start" onClick={() => setMobileOpen(true)} aria-label="menu">
+                <MenuIcon />
+              </IconButton>
+            )}
+            <Typography variant="h6" noWrap component="span" sx={{ fontWeight: 700 }}>
+              {t('common.appName')}
+            </Typography>
+          </Box>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, flexShrink: 0 }}>
+            <Chip
+              size="small"
+              label={(user?.role || '').toLowerCase()}
+              sx={{
+                bgcolor: 'rgba(255,255,255,0.15)',
+                color: 'inherit',
+                fontWeight: 600,
+                display: { xs: 'none', sm: 'inline-flex' },
+              }}
+            />
+            <Typography variant="body2" noWrap sx={{ maxWidth: 140, display: { xs: 'none', md: 'block' } }}>
+              {user?.full_name}
+            </Typography>
+            <LanguageSwitcher
+              sx={{
+                '& .MuiToggleButton-root': {
+                  color: 'inherit',
+                  borderColor: 'rgba(255,255,255,0.35)',
+                  py: 0.25,
+                },
+                '& .Mui-selected': { bgcolor: 'rgba(255,255,255,0.2) !important', color: '#fff !important' },
+              }}
+            />
+            <Typography
+              component="button"
+              type="button"
+              onClick={() => logout()}
+              sx={{
+                ml: 0.5,
+                background: 'none',
+                border: 'none',
+                color: 'inherit',
+                cursor: 'pointer',
+                font: 'inherit',
+                fontWeight: 600,
+              }}
+            >
+              {t('common.signOut')}
+            </Typography>
+          </Box>
+        </Toolbar>
+      </AppBar>
+
+      <Box component="nav" sx={{ width: { sm: DRAWER_WIDTH }, flexShrink: { sm: 0 } }}>
+        <Drawer
+          variant="temporary"
+          open={mobileOpen}
+          onClose={() => setMobileOpen(false)}
+          ModalProps={{ keepMounted: true }}
+          sx={{
+            display: { xs: 'block', sm: 'none' },
+            '& .MuiDrawer-paper': { width: DRAWER_WIDTH, boxSizing: 'border-box' },
+          }}
+        >
+          <Toolbar />
+          {drawer}
+        </Drawer>
+        <Drawer
+          variant="permanent"
+          sx={{
+            display: { xs: 'none', sm: 'block' },
+            '& .MuiDrawer-paper': {
+              width: DRAWER_WIDTH,
+              boxSizing: 'border-box',
+              borderRight: '1px solid',
+              borderColor: 'divider',
+              bgcolor: 'background.paper',
+            },
+          }}
+          open
+        >
+          <Toolbar />
+          {drawer}
+        </Drawer>
+      </Box>
+
+      <Box
+        component="main"
+        sx={{
+          flexGrow: 1,
+          p: { xs: 2, sm: 3 },
+          pt: { xs: 10, sm: 11 },
+          width: { sm: `calc(100% - ${DRAWER_WIDTH}px)` },
+          maxWidth: 1200,
+          mx: 'auto',
+        }}
+      >
+        <Outlet />
+      </Box>
+    </Box>
+  );
+}

--- a/apps/web/src/pages/Home.tsx
+++ b/apps/web/src/pages/Home.tsx
@@ -1,78 +1,69 @@
-import { Box, Button, Typography } from '@mui/material';
+import { Box, Button, CircularProgress, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
+import { Navigate, useNavigate } from 'react-router-dom';
 import LanguageSwitcher from '../components/LanguageSwitcher';
 import { useAuth } from '../contexts/useAuth';
 
 export default function Home() {
-  const { user, isAuthenticated, isLoading, logout } = useAuth();
+  const { user, isAuthenticated, isLoading } = useAuth();
   const navigate = useNavigate();
   const { t } = useTranslation();
 
   if (isLoading) {
     return (
-      <Box sx={{ p: 4, textAlign: 'center' }}>
-        <Typography>{t('common.loading')}</Typography>
-      </Box>
-    );
-  }
-
-  if (!isAuthenticated || !user) {
-    return (
       <Box
         sx={{
           minHeight: '100vh',
           display: 'flex',
-          flexDirection: 'column',
           alignItems: 'center',
           justifyContent: 'center',
-          gap: 2,
-          bgcolor: 'grey.100',
+          bgcolor: 'background.default',
         }}
       >
-        <Box sx={{ position: 'absolute', top: 16, right: 16 }}>
-          <LanguageSwitcher />
-        </Box>
-        <Typography variant="h4">{t('home.guestHeading')}</Typography>
-        <Typography color="text.secondary">{t('home.guestSubtext')}</Typography>
-        <Box sx={{ display: 'flex', gap: 2, mt: 2 }}>
-          <Button variant="contained" onClick={() => navigate('/signin')}>
-            {t('common.signIn')}
-          </Button>
-          <Button variant="outlined" onClick={() => navigate('/signup')}>
-            {t('common.signUp')}
-          </Button>
-        </Box>
+        <CircularProgress />
       </Box>
     );
   }
 
+  if (isAuthenticated && user) {
+    return <Navigate to="/dashboard" replace />;
+  }
+
   return (
-    <Box sx={{ p: 4 }}>
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 4 }}>
-        <Typography variant="h5">
-          {t('home.welcome', { name: user.full_name })}
-        </Typography>
-        <Box sx={{ display: 'flex', gap: 2, alignItems: 'center' }}>
-          <LanguageSwitcher />
-          <Button variant="outlined" onClick={logout}>
-            {t('common.signOut')}
-          </Button>
-        </Box>
+    <Box
+      sx={{
+        minHeight: '100vh',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 2,
+        px: 2,
+        bgcolor: 'background.default',
+        backgroundImage:
+          'radial-gradient(ellipse 80% 60% at 50% -10%, rgba(13, 92, 99, 0.12), transparent 55%)',
+      }}
+    >
+      <Box sx={{ position: 'absolute', top: 16, right: 16 }}>
+        <LanguageSwitcher />
       </Box>
-      <Typography color="text.secondary">
-        {t('home.signedInAs', { email: user.email, role: user.role })}
+      <Typography variant="h3" component="h1" align="center" sx={{ fontWeight: 800, maxWidth: 520 }}>
+        {t('home.guestHeading')}
       </Typography>
-      {user.role === 'admin' && (
-        <Button
-          variant="contained"
-          color="secondary"
-          sx={{ mt: 3 }}
-          onClick={() => navigate('/admin')}
-        >
-          {t('admin.goToDashboard')}
+      <Typography color="text.secondary" align="center" sx={{ maxWidth: 440 }}>
+        {t('home.guestSubtext')}
+      </Typography>
+      <Box sx={{ display: 'flex', gap: 2, mt: 2, flexWrap: 'wrap', justifyContent: 'center' }}>
+        <Button variant="contained" size="large" onClick={() => navigate('/signin')}>
+          {t('common.signIn')}
         </Button>
-      )}
+        <Button variant="outlined" size="large" onClick={() => navigate('/signup')}>
+          {t('common.signUp')}
+        </Button>
+      </Box>
+      <Button color="inherit" size="small" sx={{ mt: 4 }} onClick={() => navigate('/forgot-password')}>
+        {t('signin.forgotPassword')}
+      </Button>
     </Box>
   );
 }

--- a/apps/web/src/pages/Signin.tsx
+++ b/apps/web/src/pages/Signin.tsx
@@ -39,7 +39,7 @@ export default function Signin() {
     try {
       const tokens = await signin({ email, password });
       setAuthTokens(tokens);
-      navigate('/', { replace: true });
+      navigate('/dashboard', { replace: true });
       window.location.reload();
     } catch (err: unknown) {
       setError(getErrorMessage(err, t('signin.failedDefault')));
@@ -69,7 +69,7 @@ export default function Signin() {
     try {
       const tokens = await verifyLoginOtp(email, otp);
       setAuthTokens(tokens);
-      navigate('/', { replace: true });
+      navigate('/dashboard', { replace: true });
       window.location.reload();
     } catch (err: unknown) {
       setError(getErrorMessage(err, t('signin.failedOtpVerify')));

--- a/apps/web/src/pages/Signup.tsx
+++ b/apps/web/src/pages/Signup.tsx
@@ -58,7 +58,7 @@ export default function Signup() {
     try {
       const tokens = await verifyEmail(email, otp);
       setAuthTokens(tokens);
-      navigate('/', { replace: true });
+      navigate('/dashboard', { replace: true });
       window.location.reload();
     } catch (err: unknown) {
       setError(

--- a/apps/web/src/pages/admin/AdminLayout.tsx
+++ b/apps/web/src/pages/admin/AdminLayout.tsx
@@ -1,5 +1,6 @@
 import {
   Box,
+  Divider,
   Drawer,
   List,
   ListItemButton,
@@ -13,6 +14,8 @@ import {
 import DashboardIcon from '@mui/icons-material/Dashboard';
 import PeopleIcon from '@mui/icons-material/People';
 import HistoryIcon from '@mui/icons-material/History';
+import PersonIcon from '@mui/icons-material/Person';
+import WorkIcon from '@mui/icons-material/Work';
 import { useTranslation } from 'react-i18next';
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 import LanguageSwitcher from '../../components/LanguageSwitcher';
@@ -41,7 +44,16 @@ export default function AdminLayout() {
           </Typography>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
             <Typography variant="body2">{user?.full_name}</Typography>
-            <LanguageSwitcher />
+            <LanguageSwitcher
+              sx={{
+                '& .MuiToggleButton-root': {
+                  color: 'inherit',
+                  borderColor: 'rgba(255,255,255,0.35)',
+                  py: 0.25,
+                },
+                '& .Mui-selected': { bgcolor: 'rgba(255,255,255,0.2) !important', color: '#fff !important' },
+              }}
+            />
             <Button color="inherit" onClick={logout} size="small">
               {t('common.signOut')}
             </Button>
@@ -69,6 +81,24 @@ export default function AdminLayout() {
               <ListItemText primary={item.label} />
             </ListItemButton>
           ))}
+        </List>
+        <Divider sx={{ my: 1 }} />
+        <Typography variant="overline" sx={{ px: 2, color: 'text.secondary', letterSpacing: '0.08em' }}>
+          {t('admin.nav.previewWorkspaces')}
+        </Typography>
+        <List>
+          <ListItemButton onClick={() => navigate('/candidate/dashboard')}>
+            <ListItemIcon>
+              <PersonIcon />
+            </ListItemIcon>
+            <ListItemText primary={t('admin.nav.candidateHub')} />
+          </ListItemButton>
+          <ListItemButton onClick={() => navigate('/recruiter/dashboard')}>
+            <ListItemIcon>
+              <WorkIcon />
+            </ListItemIcon>
+            <ListItemText primary={t('admin.nav.recruiterHub')} />
+          </ListItemButton>
         </List>
       </Drawer>
 

--- a/apps/web/src/pages/candidate/CandidateApplicationsPage.tsx
+++ b/apps/web/src/pages/candidate/CandidateApplicationsPage.tsx
@@ -1,0 +1,58 @@
+import {
+  Box,
+  Chip,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { MOCK_APPLICATIONS } from '../../data/mockRecruit';
+
+export default function CandidateApplicationsPage() {
+  const { t } = useTranslation();
+
+  return (
+    <Box>
+      <Typography variant="h4" sx={{ mb: 0.5 }}>
+        {t('recruit.applications.title')}
+      </Typography>
+      <Typography color="text.secondary" sx={{ mb: 3 }}>
+        {t('recruit.applications.subtitle')}
+      </Typography>
+
+      <TableContainer component={Paper} variant="outlined">
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>{t('recruit.applications.colRole')}</TableCell>
+              <TableCell>{t('recruit.applications.colCompany')}</TableCell>
+              <TableCell>{t('recruit.applications.colStage')}</TableCell>
+              <TableCell align="right">{t('recruit.applications.colUpdated')}</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {MOCK_APPLICATIONS.map((row) => (
+              <TableRow key={row.id} hover>
+                <TableCell>{row.jobTitle}</TableCell>
+                <TableCell>{row.company}</TableCell>
+                <TableCell>
+                  <Chip size="small" label={t(`recruit.stage.${row.stage}`)} />
+                </TableCell>
+                <TableCell align="right">{row.updatedAt}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+
+      <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 2 }}>
+        {t('recruit.mockNotice')}
+      </Typography>
+    </Box>
+  );
+}

--- a/apps/web/src/pages/candidate/CandidateDashboard.tsx
+++ b/apps/web/src/pages/candidate/CandidateDashboard.tsx
@@ -1,0 +1,142 @@
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
+import AssignmentIcon from '@mui/icons-material/Assignment';
+import SearchIcon from '@mui/icons-material/Search';
+import TrendingUpIcon from '@mui/icons-material/TrendingUp';
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  Grid,
+  LinearProgress,
+  Stack,
+  Typography,
+} from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import { MOCK_APPLICATIONS, MOCK_JOBS } from '../../data/mockRecruit';
+
+export default function CandidateDashboard() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+
+  const activeApps = MOCK_APPLICATIONS.filter((a) => a.stage !== 'rejected').length;
+  const topJob = MOCK_JOBS[0];
+
+  return (
+    <Box>
+      <Typography variant="h4" sx={{ mb: 0.5 }}>
+        {t('recruit.candidate.dashboardTitle')}
+      </Typography>
+      <Typography color="text.secondary" sx={{ mb: 3 }}>
+        {t('recruit.candidate.dashboardSubtitle')}
+      </Typography>
+
+      <Grid container spacing={2} sx={{ mb: 3 }}>
+        <Grid size={{ xs: 12, sm: 4 }}>
+          <Card variant="outlined" sx={{ height: '100%', borderLeft: 4, borderColor: 'primary.main' }}>
+            <CardContent>
+              <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1 }}>
+                <AssignmentIcon color="primary" />
+                <Typography variant="subtitle2" color="text.secondary">
+                  {t('recruit.stats.activeApplications')}
+                </Typography>
+              </Stack>
+              <Typography variant="h3">{activeApps}</Typography>
+            </CardContent>
+          </Card>
+        </Grid>
+        <Grid size={{ xs: 12, sm: 4 }}>
+          <Card variant="outlined" sx={{ height: '100%', borderLeft: 4, borderColor: 'secondary.main' }}>
+            <CardContent>
+              <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1 }}>
+                <SearchIcon color="secondary" />
+                <Typography variant="subtitle2" color="text.secondary">
+                  {t('recruit.stats.jobsMatched')}
+                </Typography>
+              </Stack>
+              <Typography variant="h3">{MOCK_JOBS.length}</Typography>
+            </CardContent>
+          </Card>
+        </Grid>
+        <Grid size={{ xs: 12, sm: 4 }}>
+          <Card variant="outlined" sx={{ height: '100%', borderLeft: 4, borderColor: 'success.main' }}>
+            <CardContent>
+              <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1 }}>
+                <TrendingUpIcon color="success" />
+                <Typography variant="subtitle2" color="text.secondary">
+                  {t('recruit.stats.profileStrength')}
+                </Typography>
+              </Stack>
+              <Typography variant="h3">78%</Typography>
+              <LinearProgress variant="determinate" value={78} sx={{ mt: 1, height: 6, borderRadius: 1 }} />
+            </CardContent>
+          </Card>
+        </Grid>
+      </Grid>
+
+      <Grid container spacing={3}>
+        <Grid size={{ xs: 12, md: 7 }}>
+          <Card>
+            <CardContent>
+              <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 2 }}>
+                <Typography variant="h6">{t('recruit.candidate.topMatch')}</Typography>
+                <Button endIcon={<ArrowForwardIcon />} onClick={() => navigate('/candidate/jobs')}>
+                  {t('recruit.candidate.browseJobs')}
+                </Button>
+              </Stack>
+              <Typography variant="subtitle1" fontWeight={700}>
+                {topJob.title}
+              </Typography>
+              <Typography color="text.secondary">{topJob.company}</Typography>
+              <Stack direction="row" spacing={1} sx={{ mt: 2, flexWrap: 'wrap', gap: 1 }}>
+                <Chip size="small" label={topJob.location} />
+                <Chip size="small" label={t(`recruit.jobType.${topJob.type}`)} variant="outlined" />
+                <Chip size="small" color="primary" label={`${topJob.matchPct}% ${t('recruit.match')}`} />
+              </Stack>
+            </CardContent>
+          </Card>
+        </Grid>
+        <Grid size={{ xs: 12, md: 5 }}>
+          <Card sx={{ height: '100%' }}>
+            <CardContent>
+              <Typography variant="h6" sx={{ mb: 2 }}>
+                {t('recruit.candidate.pipelinePreview')}
+              </Typography>
+              <Stack spacing={1.5}>
+                {MOCK_APPLICATIONS.map((a) => (
+                  <Box
+                    key={a.id}
+                    sx={{
+                      p: 1.5,
+                      borderRadius: 2,
+                      bgcolor: 'action.hover',
+                      display: 'flex',
+                      justifyContent: 'space-between',
+                      alignItems: 'center',
+                      gap: 1,
+                    }}
+                  >
+                    <Box sx={{ minWidth: 0 }}>
+                      <Typography variant="body2" fontWeight={600} noWrap>
+                        {a.jobTitle}
+                      </Typography>
+                      <Typography variant="caption" color="text.secondary" noWrap>
+                        {a.company}
+                      </Typography>
+                    </Box>
+                    <Chip size="small" label={t(`recruit.stage.${a.stage}`)} color="primary" variant="outlined" />
+                  </Box>
+                ))}
+              </Stack>
+              <Button fullWidth sx={{ mt: 2 }} onClick={() => navigate('/candidate/applications')}>
+                {t('recruit.candidate.viewApplications')}
+              </Button>
+            </CardContent>
+          </Card>
+        </Grid>
+      </Grid>
+    </Box>
+  );
+}

--- a/apps/web/src/pages/candidate/CandidateJobsPage.tsx
+++ b/apps/web/src/pages/candidate/CandidateJobsPage.tsx
@@ -1,0 +1,69 @@
+import LocationOnIcon from '@mui/icons-material/LocationOn';
+import {
+  Box,
+  Button,
+  Card,
+  CardActions,
+  CardContent,
+  Chip,
+  Stack,
+  Typography,
+} from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { MOCK_JOBS } from '../../data/mockRecruit';
+
+export default function CandidateJobsPage() {
+  const { t } = useTranslation();
+
+  return (
+    <Box>
+      <Typography variant="h4" sx={{ mb: 0.5 }}>
+        {t('recruit.jobs.browseTitle')}
+      </Typography>
+      <Typography color="text.secondary" sx={{ mb: 3 }}>
+        {t('recruit.jobs.browseSubtitle')}
+      </Typography>
+
+      <Stack spacing={2}>
+        {MOCK_JOBS.map((job) => (
+          <Card key={job.id} variant="outlined">
+            <CardContent>
+              <Stack
+                direction={{ xs: 'column', sm: 'row' }}
+                justifyContent="space-between"
+                alignItems={{ xs: 'flex-start', sm: 'flex-start' }}
+                spacing={2}
+              >
+                <Box>
+                  <Typography variant="h6">{job.title}</Typography>
+                  <Typography color="text.secondary">{job.company}</Typography>
+                  <Stack direction="row" spacing={1} alignItems="center" sx={{ mt: 1 }}>
+                    <LocationOnIcon sx={{ fontSize: 18, color: 'text.secondary' }} />
+                    <Typography variant="body2" color="text.secondary">
+                      {job.location}
+                    </Typography>
+                  </Stack>
+                  <Stack direction="row" spacing={1} sx={{ mt: 1.5, flexWrap: 'wrap', gap: 1 }}>
+                    <Chip size="small" label={t(`recruit.jobType.${job.type}`)} />
+                    <Chip size="small" label={job.postedAt} variant="outlined" />
+                    <Chip size="small" color="primary" label={`${job.matchPct}% ${t('recruit.match')}`} />
+                  </Stack>
+                </Box>
+              </Stack>
+            </CardContent>
+            <CardActions sx={{ px: 2, pb: 2, pt: 0 }}>
+              <Button variant="contained" size="small">
+                {t('recruit.jobs.apply')}
+              </Button>
+              <Button size="small">{t('recruit.jobs.save')}</Button>
+            </CardActions>
+          </Card>
+        ))}
+      </Stack>
+
+      <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 3 }}>
+        {t('recruit.mockNotice')}
+      </Typography>
+    </Box>
+  );
+}

--- a/apps/web/src/pages/recruiter/RecruiterCandidatesPage.tsx
+++ b/apps/web/src/pages/recruiter/RecruiterCandidatesPage.tsx
@@ -1,0 +1,58 @@
+import {
+  Box,
+  Chip,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { MOCK_PIPELINE } from '../../data/mockRecruit';
+
+export default function RecruiterCandidatesPage() {
+  const { t } = useTranslation();
+
+  return (
+    <Box>
+      <Typography variant="h4" sx={{ mb: 0.5 }}>
+        {t('recruit.pipeline.title')}
+      </Typography>
+      <Typography color="text.secondary" sx={{ mb: 3 }}>
+        {t('recruit.pipeline.subtitle')}
+      </Typography>
+
+      <TableContainer component={Paper} variant="outlined">
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>{t('recruit.pipeline.colCandidate')}</TableCell>
+              <TableCell>{t('recruit.pipeline.colRole')}</TableCell>
+              <TableCell>{t('recruit.pipeline.colStage')}</TableCell>
+              <TableCell align="right">{t('recruit.pipeline.colUpdated')}</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {MOCK_PIPELINE.map((row) => (
+              <TableRow key={row.id} hover>
+                <TableCell>{row.candidateName}</TableCell>
+                <TableCell>{row.jobTitle}</TableCell>
+                <TableCell>
+                  <Chip size="small" label={t(`recruit.pipelineStage.${row.stage}`)} />
+                </TableCell>
+                <TableCell align="right">{row.updatedAt}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+
+      <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 2 }}>
+        {t('recruit.mockNotice')}
+      </Typography>
+    </Box>
+  );
+}

--- a/apps/web/src/pages/recruiter/RecruiterDashboard.tsx
+++ b/apps/web/src/pages/recruiter/RecruiterDashboard.tsx
@@ -1,0 +1,143 @@
+import GroupIcon from '@mui/icons-material/Group';
+import PersonSearchIcon from '@mui/icons-material/PersonSearch';
+import WorkIcon from '@mui/icons-material/Work';
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Grid,
+  LinearProgress,
+  Stack,
+  Typography,
+} from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import { MOCK_PIPELINE, MOCK_RECRUITER_JOBS } from '../../data/mockRecruit';
+
+export default function RecruiterDashboard() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+
+  const openRoles = MOCK_RECRUITER_JOBS.filter((j) => j.status === 'open').length;
+  const totalApplicants = MOCK_RECRUITER_JOBS.reduce((s, j) => s + j.applicants, 0);
+  const newLeads = MOCK_PIPELINE.filter((p) => p.stage === 'new').length;
+
+  return (
+    <Box>
+      <Typography variant="h4" sx={{ mb: 0.5 }}>
+        {t('recruit.recruiter.dashboardTitle')}
+      </Typography>
+      <Typography color="text.secondary" sx={{ mb: 3 }}>
+        {t('recruit.recruiter.dashboardSubtitle')}
+      </Typography>
+
+      <Grid container spacing={2} sx={{ mb: 3 }}>
+        <Grid size={{ xs: 12, sm: 4 }}>
+          <Card variant="outlined" sx={{ borderLeft: 4, borderColor: 'primary.main', height: '100%' }}>
+            <CardContent>
+              <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1 }}>
+                <WorkIcon color="primary" />
+                <Typography variant="subtitle2" color="text.secondary">
+                  {t('recruit.stats.openRoles')}
+                </Typography>
+              </Stack>
+              <Typography variant="h3">{openRoles}</Typography>
+            </CardContent>
+          </Card>
+        </Grid>
+        <Grid size={{ xs: 12, sm: 4 }}>
+          <Card variant="outlined" sx={{ borderLeft: 4, borderColor: 'secondary.main', height: '100%' }}>
+            <CardContent>
+              <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1 }}>
+                <GroupIcon color="secondary" />
+                <Typography variant="subtitle2" color="text.secondary">
+                  {t('recruit.stats.totalApplicants')}
+                </Typography>
+              </Stack>
+              <Typography variant="h3">{totalApplicants}</Typography>
+            </CardContent>
+          </Card>
+        </Grid>
+        <Grid size={{ xs: 12, sm: 4 }}>
+          <Card variant="outlined" sx={{ borderLeft: 4, borderColor: 'info.main', height: '100%' }}>
+            <CardContent>
+              <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1 }}>
+                <PersonSearchIcon color="info" />
+                <Typography variant="subtitle2" color="text.secondary">
+                  {t('recruit.stats.newThisWeek')}
+                </Typography>
+              </Stack>
+              <Typography variant="h3">{newLeads}</Typography>
+              <LinearProgress value={65} variant="determinate" sx={{ mt: 1, height: 6, borderRadius: 1 }} />
+            </CardContent>
+          </Card>
+        </Grid>
+      </Grid>
+
+      <Grid container spacing={3}>
+        <Grid size={{ xs: 12, md: 6 }}>
+          <Card sx={{ height: '100%' }}>
+            <CardContent>
+              <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 2 }}>
+                <Typography variant="h6">{t('recruit.recruiter.yourPostings')}</Typography>
+                <Button size="small" onClick={() => navigate('/recruiter/jobs')}>
+                  {t('recruit.recruiter.manageJobs')}
+                </Button>
+              </Stack>
+              {MOCK_RECRUITER_JOBS.map((j) => (
+                <Stack
+                  key={j.id}
+                  direction="row"
+                  justifyContent="space-between"
+                  alignItems="center"
+                  sx={{ py: 1.25, borderBottom: '1px solid', borderColor: 'divider' }}
+                >
+                  <Box>
+                    <Typography fontWeight={600}>{j.title}</Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      {t('recruit.recruiter.posted', { date: j.postedAt })}
+                    </Typography>
+                  </Box>
+                  <Typography variant="body2" color="primary" fontWeight={700}>
+                    {j.applicants} {t('recruit.recruiter.applicants')}
+                  </Typography>
+                </Stack>
+              ))}
+            </CardContent>
+          </Card>
+        </Grid>
+        <Grid size={{ xs: 12, md: 6 }}>
+          <Card sx={{ height: '100%' }}>
+            <CardContent>
+              <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 2 }}>
+                <Typography variant="h6">{t('recruit.recruiter.pipelinePreview')}</Typography>
+                <Button size="small" onClick={() => navigate('/recruiter/candidates')}>
+                  {t('recruit.recruiter.openPipeline')}
+                </Button>
+              </Stack>
+              {MOCK_PIPELINE.slice(0, 4).map((p) => (
+                <Stack
+                  key={p.id}
+                  direction="row"
+                  justifyContent="space-between"
+                  sx={{ py: 1.25, borderBottom: '1px solid', borderColor: 'divider' }}
+                >
+                  <Box>
+                    <Typography fontWeight={600}>{p.candidateName}</Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      {p.jobTitle}
+                    </Typography>
+                  </Box>
+                  <Typography variant="caption" sx={{ textTransform: 'capitalize' }}>
+                    {t(`recruit.pipelineStage.${p.stage}`)}
+                  </Typography>
+                </Stack>
+              ))}
+            </CardContent>
+          </Card>
+        </Grid>
+      </Grid>
+    </Box>
+  );
+}

--- a/apps/web/src/pages/recruiter/RecruiterJobsPage.tsx
+++ b/apps/web/src/pages/recruiter/RecruiterJobsPage.tsx
@@ -1,0 +1,71 @@
+import AddIcon from '@mui/icons-material/Add';
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  Stack,
+  Typography,
+} from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { MOCK_RECRUITER_JOBS } from '../../data/mockRecruit';
+
+export default function RecruiterJobsPage() {
+  const { t } = useTranslation();
+
+  return (
+    <Box>
+      <Stack direction={{ xs: 'column', sm: 'row' }} justifyContent="space-between" alignItems={{ xs: 'stretch', sm: 'center' }} spacing={2} sx={{ mb: 3 }}>
+        <Box>
+          <Typography variant="h4" sx={{ mb: 0.5 }}>
+            {t('recruit.recruiter.jobsTitle')}
+          </Typography>
+          <Typography color="text.secondary">{t('recruit.recruiter.jobsSubtitle')}</Typography>
+        </Box>
+        <Button variant="contained" color="secondary" startIcon={<AddIcon />} size="large">
+          {t('recruit.recruiter.newPosting')}
+        </Button>
+      </Stack>
+
+      <Stack spacing={2}>
+        {MOCK_RECRUITER_JOBS.map((job) => (
+          <Card key={job.id} variant="outlined">
+            <CardContent>
+              <Stack direction={{ xs: 'column', sm: 'row' }} justifyContent="space-between" spacing={2}>
+                <Box>
+                  <Typography variant="h6">{job.title}</Typography>
+                  <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+                    {t('recruit.recruiter.posted', { date: job.postedAt })}
+                  </Typography>
+                  <Stack direction="row" spacing={1} sx={{ mt: 1.5 }}>
+                    <Chip
+                      size="small"
+                      label={t(`recruit.jobStatus.${job.status}`)}
+                      color={job.status === 'open' ? 'success' : job.status === 'paused' ? 'warning' : 'default'}
+                    />
+                    <Chip
+                      size="small"
+                      variant="outlined"
+                      label={`${job.applicants} ${t('recruit.recruiter.applicants')}`}
+                    />
+                  </Stack>
+                </Box>
+                <Stack direction="row" spacing={1} alignItems="center">
+                  <Button size="small">{t('recruit.recruiter.edit')}</Button>
+                  <Button size="small" color="secondary">
+                    {t('recruit.recruiter.viewApplicants')}
+                  </Button>
+                </Stack>
+              </Stack>
+            </CardContent>
+          </Card>
+        ))}
+      </Stack>
+
+      <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 3 }}>
+        {t('recruit.mockNotice')}
+      </Typography>
+    </Box>
+  );
+}

--- a/apps/web/src/pages/shared/ProfilePage.tsx
+++ b/apps/web/src/pages/shared/ProfilePage.tsx
@@ -1,0 +1,86 @@
+import EmailIcon from '@mui/icons-material/Email';
+import PersonIcon from '@mui/icons-material/Person';
+import PhoneIcon from '@mui/icons-material/Phone';
+import ShieldIcon from '@mui/icons-material/Shield';
+import {
+  Box,
+  Card,
+  CardContent,
+  Divider,
+  Stack,
+  Typography,
+} from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { useAuth } from '../../contexts/useAuth';
+
+export default function ProfilePage() {
+  const { t } = useTranslation();
+  const { user } = useAuth();
+
+  if (!user) return null;
+
+  return (
+    <Box>
+      <Typography variant="h4" sx={{ mb: 0.5 }}>
+        {t('recruit.profile.title')}
+      </Typography>
+      <Typography color="text.secondary" sx={{ mb: 3 }}>
+        {t('recruit.profile.subtitle')}
+      </Typography>
+
+      <Card>
+        <CardContent>
+          <Stack spacing={2}>
+            <Stack direction="row" spacing={2} alignItems="flex-start">
+              <PersonIcon color="primary" sx={{ mt: 0.25 }} />
+              <Box>
+                <Typography variant="caption" color="text.secondary">
+                  {t('signup.fullName')}
+                </Typography>
+                <Typography fontWeight={600}>{user.full_name}</Typography>
+              </Box>
+            </Stack>
+            <Divider />
+            <Stack direction="row" spacing={2} alignItems="flex-start">
+              <EmailIcon color="primary" sx={{ mt: 0.25 }} />
+              <Box>
+                <Typography variant="caption" color="text.secondary">
+                  {t('common.email')}
+                </Typography>
+                <Typography>{user.email}</Typography>
+              </Box>
+            </Stack>
+            {user.phone && (
+              <>
+                <Divider />
+                <Stack direction="row" spacing={2} alignItems="flex-start">
+                  <PhoneIcon color="primary" sx={{ mt: 0.25 }} />
+                  <Box>
+                    <Typography variant="caption" color="text.secondary">
+                      {t('signup.phone')}
+                    </Typography>
+                    <Typography>{user.phone}</Typography>
+                  </Box>
+                </Stack>
+              </>
+            )}
+            <Divider />
+            <Stack direction="row" spacing={2} alignItems="flex-start">
+              <ShieldIcon color="primary" sx={{ mt: 0.25 }} />
+              <Box>
+                <Typography variant="caption" color="text.secondary">
+                  {t('recruit.profile.role')}
+                </Typography>
+                <Typography sx={{ textTransform: 'capitalize' }}>{user.role}</Typography>
+              </Box>
+            </Stack>
+          </Stack>
+        </CardContent>
+      </Card>
+
+      <Typography variant="body2" color="text.secondary" sx={{ mt: 3 }}>
+        {t('recruit.profile.editHint')}
+      </Typography>
+    </Box>
+  );
+}

--- a/apps/web/src/theme.ts
+++ b/apps/web/src/theme.ts
@@ -1,0 +1,57 @@
+import { createTheme } from '@mui/material/styles';
+
+/** Recruitment-focused palette: deep ocean + warm accent (distinct from default MUI blue). */
+export const appTheme = createTheme({
+  palette: {
+    mode: 'light',
+    primary: {
+      main: '#0d5c63',
+      light: '#3d858c',
+      dark: '#084046',
+      contrastText: '#f8fafb',
+    },
+    secondary: {
+      main: '#c45c26',
+      light: '#e07a45',
+      dark: '#8f3f18',
+      contrastText: '#fff8f5',
+    },
+    background: {
+      default: '#f0f4f5',
+      paper: '#ffffff',
+    },
+    text: {
+      primary: '#1a2e33',
+      secondary: '#4a6670',
+    },
+  },
+  typography: {
+    fontFamily: '"DM Sans", "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
+    h4: { fontWeight: 700, letterSpacing: '-0.02em' },
+    h5: { fontWeight: 700, letterSpacing: '-0.01em' },
+    h6: { fontWeight: 600 },
+    subtitle1: { fontWeight: 500 },
+  },
+  shape: { borderRadius: 12 },
+  components: {
+    MuiButton: {
+      defaultProps: { disableElevation: true },
+      styleOverrides: { root: { textTransform: 'none', fontWeight: 600 } },
+    },
+    MuiCard: {
+      styleOverrides: {
+        root: {
+          borderRadius: 12,
+          boxShadow: '0 1px 3px rgba(13, 92, 99, 0.08), 0 4px 12px rgba(13, 92, 99, 0.06)',
+        },
+      },
+    },
+    MuiAppBar: {
+      styleOverrides: {
+        root: {
+          backgroundImage: 'linear-gradient(135deg, #0d5c63 0%, #127a84 100%)',
+        },
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary
Adds role-based recruitment workspaces for **candidates** and **recruiters** (dashboards, jobs, applications/pipeline, profile) with mock data until job/application APIs exist. Introduces a shared app theme, /dashboard redirect to the correct hub by role, and admin sidebar links to preview both hubs.

## Changes
- **UI:** \RecruitLayout\, candidate and recruiter pages, shared \ProfilePage\, \mockRecruit.ts\, \	heme.ts\ (DM Sans + palette), \index.html\ title/fonts.
- **Routing:** \/candidate/*\, \/recruiter/*\, centralized \DashboardRedirect\ at \/dashboard\; sign-in, sign-up, and guest redirects updated.
- **Admin:** Preview section (candidate hub + recruiter hub), language switcher styling on app bar.
- **i18n:** \
ecruit.*\ strings and admin nav keys (en/am).

## How to verify
Run the web app, sign in as candidate vs recruiter vs admin; confirm \/dashboard\ lands on the expected hub and navigation matches role.

By Abdellah