### PR TITLE
chore: scaffold shared packages (ai-engine, database, utils)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,13 @@ jobs:
           pip install -r requirements.txt
           pip install ruff
 
+      - name: Verify shared packages
+        run: |
+          pip install -e packages/ai-engine
+          pip install -e packages/database
+          pip install -e packages/utils
+          python -c "from ai_engine import __version__; from recruit_database import CriteriaWeights; from recruit_utils import normalize_whitespace; CriteriaWeights(); assert normalize_whitespace('  a  b  ') == 'a b'"
+
       - name: Lint (ruff)
         run: |
           cd apps/api

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -13,6 +13,24 @@
 - Auth UI: signup, signin, OTP verify
 - Axios API client with bearer token interceptor
 
+## Packages (shared Python)
+
+Install from repo root for local dev (Docker API image still uses `apps/api` only until compose copies `packages/`):
+
+```powershell
+pip install -e ./packages/ai-engine
+pip install -e ./packages/database
+pip install -e ./packages/utils
+```
+
+| Package | Role |
+|--------|------|
+| `packages/ai-engine` (`recruit-ai-engine`) | CV parsing, TF‑IDF / embedding scoring, exams, XAI — **imported by `apps/api`** as logic is implemented. |
+| `packages/database` (`recruit-database`) | Portable types (e.g. `CriteriaWeights`), JSON shapes; **PostgreSQL + pgvector** DDL remains under **Alembic in `apps/api`**. |
+| `packages/utils` (`recruit-utils`) | Shared text utilities; Amharic/Unicode normalization as needed. |
+
+**North star:** phased AI delivery; hybrid lexical + LLM; no replacement of Alembic.
+
 ## Docker
 
 - `docker/api.Dockerfile`: backend image

--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ fypimp103/
 │  ├─ api.Dockerfile
 │  ├─ web.Dockerfile
 │  └─ docker-compose.yml
-├─ packages/                  # Reserved for shared libs
+├─ packages/                  # Shared Python libs (install with pip -e; see ARCHITECTURE.md)
+│  ├─ ai-engine/              # CV parsing, scoring, XAI (scaffold)
+│  ├─ database/               # Shared Pydantic types / JSON shapes (Alembic stays in apps/api)
+│  └─ utils/                  # Text helpers, future Amharic normalization
 ├─ scripts/
 ├─ .github/workflows/
 ├─ ARCHITECTURE.md

--- a/packages/ai-engine/pyproject.toml
+++ b/packages/ai-engine/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "recruit-ai-engine"
+version = "0.1.0"
+description = "EAA Recruit: CV parsing, scoring, XAI, exams (scaffold — logic added in later phases)"
+requires-python = ">=3.11"
+dependencies = []
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/packages/ai-engine/src/ai_engine/__init__.py
+++ b/packages/ai-engine/src/ai_engine/__init__.py
@@ -1,0 +1,9 @@
+"""Shared AI pipeline for EAA Recruit (RAG, hybrid search, scoring, XAI).
+
+Phased implementation: CVParserService, ScoringEngine, and XAI flows will live here
+as the API imports this package. Keep side-effect-free imports for FastAPI startup.
+"""
+
+__version__ = "0.1.0"
+
+__all__ = ["__version__"]

--- a/packages/database/pyproject.toml
+++ b/packages/database/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "recruit-database"
+version = "0.1.0"
+description = "Shared schemas and types for PostgreSQL / JSONB / future pgvector (Alembic stays in apps/api)"
+requires-python = ">=3.11"
+dependencies = [
+  "pydantic>=2.0,<3",
+]
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/packages/database/src/recruit_database/__init__.py
+++ b/packages/database/src/recruit_database/__init__.py
@@ -1,0 +1,10 @@
+"""Shared recruitment data shapes (criteria weights, parsed CV payloads, etc.).
+
+Database migrations remain in ``apps/api/alembic``; this package holds portable types.
+"""
+
+from recruit_database.criteria_weights import CriteriaWeights
+
+__all__ = ["CriteriaWeights", "__version__"]
+
+__version__ = "0.1.0"

--- a/packages/database/src/recruit_database/criteria_weights.py
+++ b/packages/database/src/recruit_database/criteria_weights.py
@@ -1,0 +1,18 @@
+"""Recruiter-defined weights for CV / exam / interview (SRS FR-01)."""
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class CriteriaWeights(BaseModel):
+    """Weights must sum to 1.0 (100%). Defaults match SRS example proportions."""
+
+    cv: float = Field(default=0.40, ge=0.0, le=1.0, description="CV similarity weight")
+    exam: float = Field(default=0.35, ge=0.0, le=1.0, description="Written exam weight")
+    interview: float = Field(default=0.25, ge=0.0, le=1.0, description="Interview weight")
+
+    @model_validator(mode="after")
+    def weights_sum_to_one(self) -> "CriteriaWeights":
+        total = self.cv + self.exam + self.interview
+        if abs(total - 1.0) > 0.001:
+            raise ValueError(f"criteria weights must sum to 1.0, got {total:.4f}")
+        return self

--- a/packages/utils/pyproject.toml
+++ b/packages/utils/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "recruit-utils"
+version = "0.1.0"
+description = "Amharic/Unicode helpers, logging utilities (scaffold)"
+requires-python = ">=3.11"
+dependencies = []
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/packages/utils/src/recruit_utils/__init__.py
+++ b/packages/utils/src/recruit_utils/__init__.py
@@ -1,0 +1,7 @@
+"""Shared utilities for EAA Recruit (text normalization, logging helpers)."""
+
+from recruit_utils.text import normalize_whitespace
+
+__version__ = "0.1.0"
+
+__all__ = ["__version__", "normalize_whitespace"]

--- a/packages/utils/src/recruit_utils/text.py
+++ b/packages/utils/src/recruit_utils/text.py
@@ -1,0 +1,6 @@
+"""Text helpers; extend with Amharic-specific normalization as needed."""
+
+
+def normalize_whitespace(text: str) -> str:
+    """Collapse runs of whitespace; strip ends."""
+    return " ".join(text.split())


### PR DESCRIPTION
## Summary
Scaffolds the agreed **monorepo packages** for EAA Recruit AI work. **Alembic remains in \pps/api\.**

## Contents
- \packages/ai-engine\ — \
ecruit-ai-engine\, placeholder for CV parsing / scoring / XAI.
- \packages/database\ — \
ecruit-database\, \CriteriaWeights\ Pydantic model (SRS FR-01 defaults; weights sum to 1.0).
- \packages/utils\ — \
ecruit-utils\, \
ormalize_whitespace\ + future Amharic helpers.

## Docs
- \README.md\ tree + \ARCHITECTURE.md\ install instructions and **north star** note.

## CI
- Smoke step: \pip install -e\ each package and import check.

## Local dev
From repo root: \pip install -e ./packages/ai-engine\ (and database, utils). Docker API build unchanged (context \pps/api\).


By Abdellah