### PR TITLE
feat(release): add P0 readiness pack and weighted scoring transparency

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,3 +180,10 @@ Recruiter job list/detail (`GET /api/recruiter/jobs`) includes **`applicants_cou
 - **Database:** Alembic migrations as source of truth; integration test for downgrade → upgrade on PostgreSQL
 - **Observability:** structured request logging (`app.request` logger: method, path, status, duration; `X-Request-ID` response header)
 - **44+** pytest integration tests (auth + admin + migrations + recruiter + public jobs); CI runs the suite against Postgres
+
+## Ops Runbooks
+
+- `docs/ops/backup-restore-runbook.md`
+- `docs/ops/incident-runbook.md`
+- `docs/ops/release-rehearsal-checklist.md`
+- `docs/ops/monitoring-log-checklist.md`

--- a/apps/api/app/candidate/routes.py
+++ b/apps/api/app/candidate/routes.py
@@ -1,3 +1,4 @@
+from ai_engine.match import weighted_score_breakdown
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
@@ -26,6 +27,10 @@ def list_my_applications(
     )
     out: list[CandidateApplicationOut] = []
     for app_row, job in rows:
+        scores = weighted_score_breakdown(
+            cv_similarity_score=app_row.cv_similarity_score,
+            criteria_weights=job.criteria_weights if isinstance(job.criteria_weights, dict) else None,
+        )
         out.append(
             CandidateApplicationOut(
                 id=app_row.id,
@@ -34,6 +39,8 @@ def list_my_applications(
                 company_name=job.company_name,
                 stage=app_row.stage,
                 cv_similarity_score=app_row.cv_similarity_score,
+                weighted_total_score=scores["weighted_total_score"],
+                score_breakdown=scores,
                 created_at=app_row.created_at,
                 updated_at=app_row.updated_at,
             )

--- a/apps/api/app/candidate/schemas.py
+++ b/apps/api/app/candidate/schemas.py
@@ -11,6 +11,8 @@ class CandidateApplicationOut(BaseModel):
     company_name: Optional[str]
     stage: str
     cv_similarity_score: Optional[float] = None
+    weighted_total_score: Optional[float] = None
+    score_breakdown: Optional[dict] = None
     created_at: Optional[datetime]
     updated_at: Optional[datetime]
 

--- a/apps/api/app/jobs/routes.py
+++ b/apps/api/app/jobs/routes.py
@@ -1,6 +1,6 @@
 import uuid
 
-from ai_engine.match import cv_job_similarity
+from ai_engine.match import cv_job_similarity, weighted_score_breakdown
 from fastapi import APIRouter, Body, Depends, HTTPException, Query, status
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
@@ -20,6 +20,13 @@ _candidate = require_roles("candidate", "admin")
 def _job_text_for_match(job: Job) -> str:
     parts = [job.title or "", (job.description or "").strip()]
     return "\n".join(p for p in parts if p)
+
+
+def _application_scores(cv_similarity_score: float | None, job: Job) -> dict[str, float]:
+    return weighted_score_breakdown(
+        cv_similarity_score=cv_similarity_score,
+        criteria_weights=job.criteria_weights if isinstance(job.criteria_weights, dict) else None,
+    )
 
 
 @router.post("/{job_id}/apply", response_model=CandidateApplicationOut, status_code=status.HTTP_201_CREATED)
@@ -64,6 +71,7 @@ def apply_to_open_job(
     except IntegrityError:
         db.rollback()
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Already applied to this job") from None
+    scores = _application_scores(row.cv_similarity_score, job)
     return CandidateApplicationOut(
         id=row.id,
         job_id=job.id,
@@ -71,6 +79,8 @@ def apply_to_open_job(
         company_name=job.company_name,
         stage=row.stage,
         cv_similarity_score=row.cv_similarity_score,
+        weighted_total_score=scores["weighted_total_score"],
+        score_breakdown=scores,
         created_at=row.created_at,
         updated_at=row.updated_at,
     )

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -5,6 +5,7 @@ import uuid
 
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
+from sqlalchemy import text
 
 from app.admin.routes import router as admin_router
 from app.auth.routes import router as auth_router
@@ -110,3 +111,13 @@ async def request_logging_middleware(request: Request, call_next):
 @app.get("/health")
 def health():
     return {"status": "ok"}
+
+
+@app.get("/ready")
+def readiness():
+    try:
+        with engine.connect() as conn:
+            conn.execute(text("SELECT 1"))
+        return {"status": "ready", "database": "ok"}
+    except Exception as exc:
+        raise HTTPException(status_code=503, detail="Database not ready") from exc

--- a/apps/api/app/recruiter/routes.py
+++ b/apps/api/app/recruiter/routes.py
@@ -1,5 +1,6 @@
 import uuid
 
+from ai_engine.match import weighted_score_breakdown
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import func
 from sqlalchemy.orm import Session
@@ -64,6 +65,13 @@ def _job_to_out(job: Job, applicants_count: int = 0) -> JobOut:
         created_at=job.created_at,
         updated_at=job.updated_at,
         applicants_count=applicants_count,
+    )
+
+
+def _application_scores(cv_similarity_score: float | None, job: Job) -> dict[str, float]:
+    return weighted_score_breakdown(
+        cv_similarity_score=cv_similarity_score,
+        criteria_weights=job.criteria_weights if isinstance(job.criteria_weights, dict) else None,
     )
 
 
@@ -137,6 +145,7 @@ def list_all_applications(
     rows = q.order_by(JobApplication.created_at.desc()).all()
     out: list[RecruiterApplicationOut] = []
     for app_row, cand, job in rows:
+        scores = _application_scores(app_row.cv_similarity_score, job)
         out.append(
             RecruiterApplicationOut(
                 id=app_row.id,
@@ -147,6 +156,8 @@ def list_all_applications(
                 candidate_name=cand.full_name,
                 stage=app_row.stage,
                 cv_similarity_score=app_row.cv_similarity_score,
+                weighted_total_score=scores["weighted_total_score"],
+                score_breakdown=scores,
                 created_at=app_row.created_at,
                 updated_at=app_row.updated_at,
             )
@@ -170,6 +181,7 @@ def list_job_applications(
     )
     out: list[RecruiterApplicationOut] = []
     for app_row, cand in rows:
+        scores = _application_scores(app_row.cv_similarity_score, job)
         out.append(
             RecruiterApplicationOut(
                 id=app_row.id,
@@ -180,6 +192,8 @@ def list_job_applications(
                 candidate_name=cand.full_name,
                 stage=app_row.stage,
                 cv_similarity_score=app_row.cv_similarity_score,
+                weighted_total_score=scores["weighted_total_score"],
+                score_breakdown=scores,
                 created_at=app_row.created_at,
                 updated_at=app_row.updated_at,
             )
@@ -204,6 +218,7 @@ def update_application_stage(
     cand = db.query(User).filter(User.id == app_row.candidate_id).first()
     job = db.query(Job).filter(Job.id == app_row.job_id).first()
     assert cand is not None and job is not None
+    scores = _application_scores(app_row.cv_similarity_score, job)
     return RecruiterApplicationOut(
         id=app_row.id,
         job_id=app_row.job_id,
@@ -213,6 +228,8 @@ def update_application_stage(
         candidate_name=cand.full_name,
         stage=app_row.stage,
         cv_similarity_score=app_row.cv_similarity_score,
+        weighted_total_score=scores["weighted_total_score"],
+        score_breakdown=scores,
         created_at=app_row.created_at,
         updated_at=app_row.updated_at,
     )

--- a/apps/api/app/recruiter/schemas.py
+++ b/apps/api/app/recruiter/schemas.py
@@ -62,6 +62,8 @@ class RecruiterApplicationOut(BaseModel):
     candidate_name: str
     stage: str
     cv_similarity_score: Optional[float] = None
+    weighted_total_score: Optional[float] = None
+    score_breakdown: Optional[dict] = None
     created_at: Optional[datetime]
     updated_at: Optional[datetime]
 

--- a/apps/api/tests/test_applications.py
+++ b/apps/api/tests/test_applications.py
@@ -17,6 +17,7 @@ def test_apply_with_cv_text_sets_similarity(client: TestClient, make_verified_us
             "title": "Python Developer",
             "description": "We need Python and FastAPI experience.",
             "status": "open",
+            "criteria_weights": {"cv": 0.6, "exam": 0.2, "interview": 0.2},
         },
         headers=h_rec,
     )
@@ -34,14 +35,22 @@ def test_apply_with_cv_text_sets_similarity(client: TestClient, make_verified_us
     assert body["job_id"] == job_id
     assert body["cv_similarity_score"] is not None
     assert 0.0 <= body["cv_similarity_score"] <= 1.0
+    assert body["weighted_total_score"] is not None
+    assert body["score_breakdown"]["cv_weight"] == 0.6
+    assert body["score_breakdown"]["weighted_total_score"] == body["weighted_total_score"]
+    assert body["weighted_total_score"] == body["cv_similarity_score"] * 0.6
 
     listed = client.get("/api/candidate/applications", headers=h_c).json()
     assert len(listed) == 1
     assert listed[0]["cv_similarity_score"] == body["cv_similarity_score"]
+    assert listed[0]["weighted_total_score"] == body["weighted_total_score"]
+    assert listed[0]["score_breakdown"]["cv_weight"] == 0.6
 
     rec_list = client.get(f"/api/recruiter/jobs/{job_id}/applications", headers=h_rec).json()
     assert len(rec_list) == 1
     assert rec_list[0]["cv_similarity_score"] == body["cv_similarity_score"]
+    assert rec_list[0]["weighted_total_score"] == body["weighted_total_score"]
+    assert rec_list[0]["score_breakdown"]["cv_weight"] == 0.6
 
 
 def test_candidate_apply_and_list(client: TestClient, make_verified_user):

--- a/docs/ops/backup-restore-runbook.md
+++ b/docs/ops/backup-restore-runbook.md
@@ -1,0 +1,52 @@
+# PostgreSQL Backup and Restore Runbook
+
+This runbook targets the default Docker stack in this repository.
+
+## Preconditions
+
+- Docker Desktop running.
+- Services started with `.\scripts\docker-up.ps1` or `docker compose up`.
+- Postgres reachable as configured in `docker/docker-compose.yml`.
+
+## Backup (logical dump)
+
+Run from repository root:
+
+```powershell
+docker compose -f docker/docker-compose.yml exec postgres \
+  pg_dump -U postgres -d recruit_db -Fc -f /tmp/recruit_db.dump
+docker compose -f docker/docker-compose.yml cp \
+  postgres:/tmp/recruit_db.dump ./artifacts/recruit_db.dump
+```
+
+Expected result:
+- `artifacts/recruit_db.dump` exists and is non-empty.
+
+## Restore (to target DB)
+
+Warning: this command drops and recreates schema objects in target DB.
+
+```powershell
+docker compose -f docker/docker-compose.yml cp \
+  ./artifacts/recruit_db.dump postgres:/tmp/recruit_db.dump
+docker compose -f docker/docker-compose.yml exec postgres \
+  pg_restore -U postgres -d recruit_db --clean --if-exists /tmp/recruit_db.dump
+```
+
+## Verification
+
+```powershell
+docker compose -f docker/docker-compose.yml exec postgres \
+  psql -U postgres -d recruit_db -c "\dt"
+curl http://localhost:8000/ready
+```
+
+Pass criteria:
+- Key tables exist (`users`, `jobs`, `job_applications`, etc.).
+- API readiness endpoint returns HTTP `200`.
+
+## Rehearsal Evidence (fill after each drill)
+
+| Date | Operator | Environment | Backup path | Restore target | Result | Notes |
+|---|---|---|---|---|---|---|
+| YYYY-MM-DD | @owner | local/staging | `artifacts/recruit_db.dump` | `recruit_db` | pass/fail | observations |

--- a/docs/ops/incident-runbook.md
+++ b/docs/ops/incident-runbook.md
@@ -1,0 +1,56 @@
+# Incident Response Runbook
+
+## Severity Levels
+
+- **SEV-1:** Full outage or major security incident.
+- **SEV-2:** Core functionality degraded (auth, apply pipeline, recruiter ops).
+- **SEV-3:** Non-critical issues with workaround.
+
+## Immediate Response
+
+1. Acknowledge incident and assign incident lead.
+2. Capture timestamps, impacted endpoints, and latest deployment reference.
+3. Check API health and readiness:
+   - `GET /health`
+   - `GET /ready`
+4. Check recent logs for request failures and exception traces.
+
+## Technical Triage
+
+1. Verify Postgres health:
+   - `docker compose -f docker/docker-compose.yml ps`
+   - `pg_isready` from Postgres container.
+2. Verify migration state:
+   - `cd apps/api && python -m alembic current`
+3. Confirm shared packages importability in API runtime:
+   - `python -c "from ai_engine import cv_job_similarity; from recruit_database import CriteriaWeights; print('ok')"`
+
+## Mitigation Paths
+
+- **If caused by latest deploy:** execute rollback plan from release checklist.
+- **If DB issue:** restore from latest known-good backup.
+- **If external dependency issue:** disable non-critical dependency paths and keep core APIs available.
+
+## Communication
+
+- Update stakeholders every 30 minutes for SEV-1/SEV-2.
+- Include impact, mitigation status, ETA, and next update time.
+
+## Closure
+
+1. Confirm system health and readiness stable.
+2. Document root cause and preventive actions.
+3. Create follow-up tasks and assign owners with due dates.
+
+## Postmortem Template
+
+| Field | Details |
+|---|---|
+| Incident ID | |
+| Severity | |
+| Start/End time | |
+| User impact | |
+| Root cause | |
+| Detection gap | |
+| Actions taken | |
+| Preventive actions | |

--- a/docs/ops/monitoring-log-checklist.md
+++ b/docs/ops/monitoring-log-checklist.md
@@ -1,0 +1,33 @@
+# Monitoring and Log Review Checklist
+
+## Runtime Signal Checks
+
+- [ ] API process healthy.
+- [ ] `/health` response is `200`.
+- [ ] `/ready` response is `200` and DB connectivity validated.
+- [ ] Postgres container/service healthy.
+
+## Log Quality Checks
+
+- [ ] Request logs include method/path/status/duration.
+- [ ] `X-Request-ID` is present in responses for correlation.
+- [ ] Error logs include stack traces for unexpected exceptions.
+- [ ] No sensitive values (passwords/tokens/secrets) appear in logs.
+
+## Functional Monitoring Checks
+
+- [ ] Auth endpoints within expected success/error range.
+- [ ] Candidate apply endpoint error rate monitored.
+- [ ] Recruiter job/application endpoints operational.
+
+## Escalation Triggers
+
+- [ ] Sustained API 5xx above threshold.
+- [ ] Readiness failures for more than 5 minutes.
+- [ ] Login/apply path availability below agreed SLO.
+
+## Evidence Record
+
+| Date | Reviewer | Environment | Result | Notes |
+|---|---|---|---|---|
+| YYYY-MM-DD | @owner | local/staging/prod | pass/fail | |

--- a/docs/ops/release-rehearsal-checklist.md
+++ b/docs/ops/release-rehearsal-checklist.md
@@ -1,0 +1,41 @@
+# Release Rehearsal and Rollback Checklist
+
+Use this checklist before production cut.
+
+## Pre-Deployment
+
+- [ ] Branch and commit hash frozen for release candidate.
+- [ ] CI pipeline green (backend + frontend).
+- [ ] Alembic migrations reviewed for forward/backward safety.
+- [ ] Backup taken and verified (`docs/ops/backup-restore-runbook.md`).
+- [ ] Runbooks reviewed by incident lead.
+
+## Deployment Rehearsal (staging-like)
+
+- [ ] Deploy images/stack using release candidate artifacts.
+- [ ] Run migration step (`alembic upgrade head`).
+- [ ] Validate API:
+  - [ ] `/health` returns 200.
+  - [ ] `/ready` returns 200.
+  - [ ] Auth smoke test.
+  - [ ] Recruiter job CRUD smoke test.
+  - [ ] Candidate apply smoke test.
+- [ ] Validate frontend:
+  - [ ] Auth/login pages load.
+  - [ ] Candidate jobs/applications page loads.
+  - [ ] Recruiter jobs/applicants page loads.
+
+## Rollback Rehearsal
+
+- [ ] Confirm last known-good image/tag.
+- [ ] Revert app deployment to previous version.
+- [ ] Validate API and frontend smoke checks on rolled-back version.
+- [ ] Restore DB from backup in a non-production environment and validate integrity.
+
+## Signoff
+
+| Role | Name | Date | Decision |
+|---|---|---|---|
+| Engineering lead | | | approve/reject |
+| QA/test owner | | | approve/reject |
+| Ops/release owner | | | approve/reject |

--- a/docs/planning/requirements-traceability.md
+++ b/docs/planning/requirements-traceability.md
@@ -1,0 +1,38 @@
+# Requirements Traceability Matrix (SRS/SDS)
+
+This matrix links requirement IDs to delivery priority, schedule, evidence, and status.
+
+Status values:
+- `not_started`
+- `in_progress`
+- `done`
+- `deferred`
+
+## Template
+
+| Requirement ID | Summary | Priority | Planned Week | Owner | Evidence (tests/docs/path) | Status |
+|---|---|---|---|---|---|---|
+| FR-XX | Requirement summary | P0/P1/P2 | 1/2/3/4 | @owner | `path/to/test_or_doc` | not_started |
+
+## Initial Mapping (current baseline)
+
+| Requirement ID | Summary | Priority | Planned Week | Owner | Evidence (tests/docs/path) | Status |
+|---|---|---|---|---|---|---|
+| FR-01 | Recruiter criteria weights (`cv`, `exam`, `interview`) sum to 1.0 and are persisted with jobs | P0 | 2 | backend | `packages/database/src/recruit_database/criteria_weights.py`, `apps/api/tests/test_recruiter_jobs.py` | done |
+| FR-03 | Candidate apply supports optional CV text and TF-IDF/cosine CV-job matching | P0 | 1 | backend | `packages/ai-engine/src/ai_engine/match.py`, `apps/api/tests/test_applications.py` | done |
+| FR-APP-LIST | Candidate/recruiter application views expose CV similarity score | P0 | 1 | backend/web | `apps/api/app/candidate/routes.py`, `apps/api/app/recruiter/routes.py`, `apps/web/src/pages/candidate/CandidateApplicationsPage.tsx` | done |
+| NFR-OPS-HEALTH | Service health endpoint available for runtime checks | P0 | 1 | backend | `apps/api/app/main.py` | done |
+| NFR-TRACE-LOG | Structured request logging with request correlation ID | P0 | 2 | backend | `apps/api/app/main.py` | done |
+| NFR-SEC-CI | CI validates backend/frontend quality gates | P0 | 1 | devops | `.github/workflows/ci.yml` | done |
+| NFR-OPS-BACKUP | Postgres backup/restore runbook documented and rehearsal evidence tracked | P0 | 3 | devops | `docs/ops/backup-restore-runbook.md` | in_progress |
+| NFR-OPS-INCIDENT | Incident response and rollback runbooks documented | P0 | 3 | devops | `docs/ops/incident-runbook.md`, `docs/ops/release-rehearsal-checklist.md` | in_progress |
+| FR-EXAM | Exam authoring/submission/grading workflow | P1 | 3 | backend/web | `TBD` | not_started |
+| FR-XAI | Explainable AI output for score breakdown and rationale | P1 | 4 | backend/web | `TBD` | not_started |
+| NFR-FAIRNESS | Bias/fairness checks and audit trail policy | P2 | 4 | ai/backend | `TBD` | not_started |
+
+## Update Process
+
+1. Add every new SRS/SDS requirement row before implementation starts.
+2. Keep `Priority` and `Planned Week` aligned with the release plan.
+3. Do not mark `done` without a concrete evidence path.
+4. For deferred items, add reason in PR description and update the backlog doc.

--- a/docs/planning/weighted-scoring.md
+++ b/docs/planning/weighted-scoring.md
@@ -1,0 +1,36 @@
+# Weighted Transparent Scoring (Current Phase)
+
+## Purpose
+
+Expose a deterministic, auditable score breakdown per application while exam/interview modules are still pending.
+
+## Formula
+
+Given recruiter criteria weights:
+- `cv_weight`
+- `exam_weight`
+- `interview_weight`
+
+And component scores:
+- `cv_score`: TF-IDF/cosine similarity in `[0, 1]`
+- `exam_score`: placeholder `0.0` (until exam feature ships)
+- `interview_score`: placeholder `0.0` (until interview scoring ships)
+
+Weighted total:
+
+`weighted_total_score = cv_weight * cv_score + exam_weight * exam_score + interview_weight * interview_score`
+
+## API Exposure
+
+Application responses now include:
+- `cv_similarity_score`
+- `weighted_total_score`
+- `score_breakdown` (weights, component scores, and weighted total)
+
+## Code References
+
+- `packages/ai-engine/src/ai_engine/match.py` (`weighted_score_breakdown`)
+- `apps/api/app/jobs/routes.py`
+- `apps/api/app/candidate/routes.py`
+- `apps/api/app/recruiter/routes.py`
+- `apps/api/tests/test_applications.py`

--- a/docs/release/p0-scope-checklist.md
+++ b/docs/release/p0-scope-checklist.md
@@ -1,0 +1,44 @@
+# P0 Scope Lock (Strict Production-Ready)
+
+This checklist defines the non-negotiable P0 release bar.
+
+## P0 Functional Scope
+
+- [x] Authentication and role-based access control for candidate/recruiter/admin.
+- [x] Recruiter job CRUD with criteria weights support.
+- [x] Public open-job browse endpoints.
+- [x] Candidate apply flow with duplicate/ownership guards.
+- [x] Candidate and recruiter application views with stage progression.
+- [x] CV similarity scoring (TF-IDF + cosine) captured on application.
+- [ ] Weighted transparent scoring (criteria-aware composite) exposed in API responses.
+
+## P0 Reliability and Operations
+
+- [x] Alembic migrations are source-of-truth and run at startup/init.
+- [x] CI quality gates for backend/frontend are enabled.
+- [x] Health endpoint exists (`/health`).
+- [ ] Readiness endpoint verifies DB connectivity (`/ready`).
+- [ ] Backup and restore runbook completed and rehearsal evidence recorded.
+- [ ] Release rehearsal checklist completed in staging-like environment.
+- [ ] Rollback procedure documented and rehearsal evidence recorded.
+
+## P0 Security Baseline
+
+- [x] JWT auth and refresh/session behavior implemented.
+- [x] Rate limiting on sensitive auth endpoints.
+- [x] Account lockout policy.
+- [ ] Security verification checklist completed before release cut.
+- [ ] Dependency scan and secrets hygiene review attached to release evidence.
+
+## P0 Observability
+
+- [x] Request logs include method/path/status/duration.
+- [x] Response includes request correlation header (`X-Request-ID`).
+- [ ] Monitoring/log review checklist completed with signoff.
+
+## Exit Gate
+
+Release can proceed only when:
+1. All P0 boxes are checked, or exceptions are explicitly waived.
+2. Evidence links are recorded in release signoff.
+3. Deferred items are moved to P1/P2 backlog with owner and due window.

--- a/docs/release/p0-signoff.md
+++ b/docs/release/p0-signoff.md
@@ -1,0 +1,38 @@
+# P0 Release Signoff (Strict Production-Ready)
+
+## Scope
+
+This signoff references:
+- `docs/release/p0-scope-checklist.md`
+- `docs/planning/requirements-traceability.md`
+- `docs/ops/*` runbooks/checklists
+
+## Validation Evidence
+
+| Area | Evidence | Result | Notes |
+|---|---|---|---|
+| Backend lint | `cd apps/api && python -m ruff check app` | pass | Completed in this cycle |
+| Weighted scoring behavior | `docs/planning/weighted-scoring.md`, `apps/api/tests/test_applications.py` | pass (code+tests updated) | Integration tests require running Postgres |
+| API health endpoint | `GET /health` (`apps/api/app/main.py`) | pass | Static endpoint |
+| API readiness endpoint | `GET /ready` (`apps/api/app/main.py`) | pass (code) | Returns 503 when DB unavailable |
+| Backup/restore runbook | `docs/ops/backup-restore-runbook.md` | pass (doc) | Rehearsal evidence table to fill during drill |
+| Incident runbook | `docs/ops/incident-runbook.md` | pass (doc) | Includes escalation and postmortem template |
+| Release/rollback checklist | `docs/ops/release-rehearsal-checklist.md` | pass (doc) | Requires staging rehearsal execution |
+| Monitoring/log checklist | `docs/ops/monitoring-log-checklist.md` | pass (doc) | Includes runtime/log quality checks |
+
+## Open Preconditions Before Production Cut
+
+1. Start Postgres and run integration tests:
+   - `cd apps/api`
+   - `python -m pytest tests/test_applications.py -q`
+2. Execute backup/restore rehearsal and fill evidence row.
+3. Execute staging release rehearsal and rollback checklist.
+4. Record final approvers in this file.
+
+## Approvals
+
+| Role | Name | Date | Decision |
+|---|---|---|---|
+| Engineering lead |  |  | pending |
+| QA/test owner |  |  | pending |
+| Ops/release owner |  |  | pending |

--- a/docs/release/p1-p2-backlog.md
+++ b/docs/release/p1-p2-backlog.md
@@ -1,0 +1,26 @@
+# Deferred Backlog (P1/P2)
+
+This backlog captures non-P0 items with ownership and target windows.
+
+## P1 (Next Priority)
+
+| Item | Owner | Target Window | Reason Deferred | Success Criteria |
+|---|---|---|---|---|
+| Exam authoring + candidate submission workflow | backend + web | Week 3 | Requires data model and UI scope beyond current P0 | Recruiter can attach exam, candidate submits, score stored |
+| Interview score input and weighting in composite score | backend + recruiter UI | Week 3 | Interview module not yet implemented | `interview_score` no longer placeholder |
+| Recruiter filtering/sorting by weighted score | web | Week 3-4 | UX enhancement after core score API | Recruiter tables sort/filter by score |
+| Readiness SLO alert automation | devops | Week 4 | Needs infra alerting integration | Alert trigger documented and tested |
+
+## P2 (Later / Nice-to-Have)
+
+| Item | Owner | Target Window | Reason Deferred | Success Criteria |
+|---|---|---|---|---|
+| XAI narrative explanation text (human-friendly) | ai/backend | Week 4+ | Depends on final scoring dimensions | API returns concise explanation text |
+| Bias/fairness checks and audit reporting | ai/backend | Week 4+ | Needs policy and data governance decisions | Repeatable fairness report process |
+| Dense embeddings with pgvector/hybrid retrieval | ai/backend | Week 4+ | Current phase uses TF-IDF baseline | Embedding similarity integrated and benchmarked |
+| Async queue for heavy AI tasks | backend/devops | Week 4+ | Not required at current load | Queue path implemented with retries/monitoring |
+
+## Review Cadence
+
+- Revalidate this backlog weekly during release planning.
+- Promote/defer items only with explicit owner and reason.

--- a/packages/ai-engine/src/ai_engine/__init__.py
+++ b/packages/ai-engine/src/ai_engine/__init__.py
@@ -3,8 +3,8 @@
 Phased implementation: CV–JD TF-IDF similarity, then richer parsing and XAI.
 """
 
-from ai_engine.match import cv_job_similarity
+from ai_engine.match import cv_job_similarity, weighted_score_breakdown
 
 __version__ = "0.2.0"
 
-__all__ = ["__version__", "cv_job_similarity"]
+__all__ = ["__version__", "cv_job_similarity", "weighted_score_breakdown"]

--- a/packages/ai-engine/src/ai_engine/match.py
+++ b/packages/ai-engine/src/ai_engine/match.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Mapping
 
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.pairwise import cosine_similarity
 
 _MAX_FEATURES = 5000
+_DEFAULT_WEIGHTS = {"cv": 0.40, "exam": 0.35, "interview": 0.25}
 
 
 def _normalize(text: str) -> str:
@@ -32,3 +34,36 @@ def cv_job_similarity(cv_text: str, job_text: str) -> float:
         return 0.0
     sim = cosine_similarity(tf[0:1], tf[1:2])[0, 0]
     return float(max(0.0, min(1.0, sim)))
+
+
+def weighted_score_breakdown(
+    cv_similarity_score: float | None,
+    criteria_weights: Mapping[str, float] | None,
+) -> dict[str, float]:
+    """Return transparent weighted scoring breakdown.
+
+    Exam and interview scores are placeholders (0.0) until those modules ship.
+    """
+    weights = dict(_DEFAULT_WEIGHTS)
+    if criteria_weights:
+        for key in ("cv", "exam", "interview"):
+            if key in criteria_weights:
+                weights[key] = float(criteria_weights[key])
+
+    cv_score = float(cv_similarity_score or 0.0)
+    exam_score = 0.0
+    interview_score = 0.0
+    weighted_total = (
+        (weights["cv"] * cv_score)
+        + (weights["exam"] * exam_score)
+        + (weights["interview"] * interview_score)
+    )
+    return {
+        "cv_weight": weights["cv"],
+        "exam_weight": weights["exam"],
+        "interview_weight": weights["interview"],
+        "cv_score": cv_score,
+        "exam_score": exam_score,
+        "interview_score": interview_score,
+        "weighted_total_score": float(max(0.0, min(1.0, weighted_total))),
+    }


### PR DESCRIPTION
## Summary
- implement strict P0 release governance artifacts: traceability matrix, scope checklist, signoff record, and P1/P2 deferred backlog
- add ops runbooks/checklists for backup/restore, incident response, release rehearsal/rollback, and monitoring-log review
- harden scoring transparency by adding weighted score breakdown fields to application API responses and documenting the formula

## Test plan
- [x] `cd apps/api && python -m ruff check app`
- [ ] `cd apps/api && python -m pytest tests/test_applications.py -q` (blocked locally: PostgreSQL at `127.0.0.1:5433` was not running)
- [ ] Manual smoke in running stack: `GET /health`, `GET /ready`, apply flow with CV text and weighted score fields